### PR TITLE
Add CDDL minimum occurrence specification

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -710,7 +710,7 @@ request-id = uint
 ; type key 14
 presentation-url-availability-request = {
   request
-  1: [* text] ; urls
+  1: [1* text] ; urls
   2: microseconds ; watch-duration
   3: int ; watch-id
 }
@@ -718,14 +718,14 @@ presentation-url-availability-request = {
 ; type key 15
 presentation-url-availability-response = {
   response
-  1: [* url-availability] ; url-availabilities
+  1: [1* url-availability] ; url-availabilities
 }
 
 ; type key 103
 presentation-url-availability-event = {
   1: int ; watch-id
-  2: [* url] ; urls
-  3: [* url-availability] ; url-availabilities
+  2: [1* url] ; urls
+  3: [1* url-availability] ; url-availabilities
 }
 
 


### PR DESCRIPTION
The presentation-url-availability-* messages were changed to require
non-empty url and availibility lists, but the corresponding CDDL wasn't
changed.  This change just updates the CDDL spec to require a minimum of
one element for the relevant arrays.