### PR TITLE
Remove unused urls in availability event

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -724,8 +724,7 @@ presentation-url-availability-response = {
 ; type key 103
 presentation-url-availability-event = {
   1: int ; watch-id
-  2: [1* url] ; urls
-  3: [1* url-availability] ; url-availabilities
+  2: [1* url-availability] ; url-availabilities
 }
 
 


### PR DESCRIPTION
presentation-url-availability-event had a |urls| member when we were
considering whether it could send just a changed subset in each event.
The final text in the #presentation-protocol section doesn't describe
this member, so it should be removed.