### PR TITLE
Adds security and privacy section to the spec.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -376,7 +376,81 @@ request they are associated with.
 Authentication {#authentication}
 ================================
 
-Issue(102): Incorporate material from the \[J-PAKE](j-pake.md) document.
+In order for one agent (the challenger) to authenticate another (the responder),
+the challenger may send an authentication-request message and expect an
+authentication-response message to best sent back from the responder.  To
+mutually authenticate, this mechanism is used twice, once by each side acting as
+the challenger.  This mechanism assumes the agents share a low-entry secret,
+such as a number or a short password that could be entered by a user on a
+keyboard or TV remote control.
+
+For all messages and objects defined in this section, see Appendix A for the full
+CDDL definitions.
+
+The challenger sends an authentication-request message with the following values:
+
+-   mechanism: The authentication mechanism being used.  This standard only
+    defines the mechanism hkdf-of-scrypt-of-psk but this field gives a place for
+    other mechanisms to be specified.
+
+-   salt: 32 random bytes (which need not be kept secret). 
+
+-   cost: log base 2 of the cost parameter (N) for scrypt defined in [RFC
+    7914 section 2](https://tools.ietf.org/html/rfc7914#section-2).  It must be
+    greater than or equal to 14 (to avoid being too weak) and less than or equal
+    to 128 (the limit defined by scrypt).  A value of 15 is recommended (an
+    scrypt N of 2^15 or 32768).
+
+The responder replies with an authentication-response message with the following values:
+
+-   result:  If the responder was able to calculate proof of possession of the
+    shared secret, and if it failed, why it failed.
+
+-   proof: The result of running
+    [HKDF](https://tools.ietf.org/html/rfc5869) on the result of running
+    [scrypt](https://tools.ietf.org/html/rfc7914) on the shared secret.  For
+    scrypt, the cost parameter (N) used is the 2 to the power of the cost from
+    the authentication-request message, the block size (r) is 8, the
+    parallelization parameter (p) is 1, and the key length derived is 32.  For
+    HKDF, both the extract and expand steps are used, the hash function used is
+    sha-256, the salt used is the salt from the authentication-request message,
+    the application-specific info is a serialized certificate-fingerprint-pair
+    object (defined below), and the length of the output key matrial (L) is 32.
+
+Note: the values of 32 above (for salt length, scrypt output key length, and
+HKDF output key material length) are based on the output size of sha-256.  If a
+different hash mechanism is used in the future, these values should be updated as
+well.
+
+The certificate-fingerprint-pair object used as application-specific info above
+is serialized as CBOR (without the type or length prefix of messages in a QUIC
+stream) and contains the following values:
+
+-   challenger-fingerprint: The certificate fingerprint of the
+    challenger, used in the QUIC crypto handshake during connection
+    establishment, as defined by [RFC 8122 section
+    5](https://tools.ietf.org/html/rfc8122#section-5).  It is the output using
+    sha-256 as the hash wihtout any hexadecimal encoding or prefixing.
+
+-   responder-fingerprint: The certificate fingerprint of the
+    responder, obtained from the QUIC crypto handshake during connection
+    establishment, as defined by [RFC 8122 section
+    5](https://tools.ietf.org/html/rfc8122#section-5).  It is the output using
+    sha-256 as the hash wihtout any hexadecimal encoding or prefixing. 
+
+To verify that the responder's proof is correct, the challenger makes the same
+calculation of the proof and compares the result. If the results are the same,
+the challenger considers the responder authenticated, and considers it
+unauthenticated otherwise.  In either case, the challenger sends the responder an
+authentication-result message with the following values:
+
+-   result:  If the challenger was able to authenticate the responder or not,
+    and if not, why not.
+
+The challenger must limit the time the responder has to send a response to 60
+seconds (to avoid the possibility of brute-force attacks.)
+
+
 
 Control Protocols {#control-protocols}
 ============================
@@ -510,8 +584,7 @@ message which contains the following values:
 
 -   presentation-id: The ID of the presentation to connect to.
 
-- url: The URL of the presentation to connect to.
-
+-   url: The URL of the presentation to connect to. 
 
 The receiver should, upon receipt of a
 presentation-connection-open-request message, send back a
@@ -966,6 +1039,53 @@ response = (
 )
 
 request-id = uint
+
+; type key 1001 
+authentication-request = {
+  request
+  1: authentication-mechanism ; mechanism
+  2: bytes ; salt
+  3: uint ; cost
+}
+
+; type key 1002 
+authentication-response = {
+  response
+  1: authentication-response-result ; result
+  2: bytes ; proof
+}
+
+certificate-fingerprint-pair = [
+  challenger-fingerprint: bytes
+  responder-fingerprint: bytes
+]
+
+; type key 1003
+authentication-result = {
+  1: authentication-result-result ; result
+}
+
+
+authentication-mechanism = &(
+  hkdf-of-scrypt-of-psk: 1
+)
+
+authentication-response-result = &(
+  ok: 0
+  unknown-error: 1
+  mechanism-unknown: 2
+  salt-too-small: 3
+  cost-too-low: 4
+  cost-too-high: 5
+  secret-unknown: 6
+  calculation-took-too-long: 7
+)
+
+authentication-result-result = &(
+  authenticated: 0
+  unknown-error: 1
+  proof-invalid: 2
+)
 
 ; type key 14
 presentation-url-availability-request = {

--- a/index.bs
+++ b/index.bs
@@ -632,18 +632,159 @@ Issue(12): Propose control protocol for Remote
 Playback API.
 
 
-Security and Privacy {#security}
-================================
+Security and Privacy {#security-privacy}
+====================
 
-The Open Screen Protocol should, at a minimum, conform to the security and
-privacy guidelines recommended by the [[PRESENTATION-API][Presentation API]] and
-the [[REMOTE-PLAYBACK][Remote Playback API]].
+The Open Screen Protocol allows two networked user agents to discover each other
+and exchange user and application data.  As such, its security and privacy
+considerations should be closely examined.  We first evaluate the protocol
+itself using the W3C [[SECURITY-PRIVACY-QUESTIONNAIRE]].  We then examine
+whether the security and privacy guidelines recommended by the
+[[PRESENTATION-API]] and the [[REMOTE-PLAYBACK] are met.
 
-In addition, the Open Screen Protocol itself adds additional security and privacy
-considerations.
+Threat Models {#threat-models}
+--------------------------------
 
-Presentation API
-----------------
+### Passive Network Attackers ### {#passive-network-attackers}
+
+The Open Screen Protocol should assume that all parties that are connected to
+the same LAN as the user agents, either through a wired connection or through
+WiFi, are able to observe all data flowing between Open Screen controllers and
+receivers.
+
+These parties will be able collect any data exposed through unencrypted
+messages, such as mDNS records and the QUIC handshake.
+
+These parties may attempt to learn cryptographic parameters by observing data
+flows on the QUIC connection, or by observing cryptographic timing.
+
+### Active Network Attackers ### {#active-network-attackers}
+
+In addition, all parties with access to the LAN will be able to manipulate data
+exchanged between controllers and receivers.  They will be able to inject
+traffic into both parties and attempt to inititate new QUIC connections.  These abilities
+can be used to attempt the following:
+
+*   Impersonate a new receiver or one already trusted by the user, in an attempt
+    to convince the user to authenticate to it.
+*   Connect to a receiver and query its capabilities.
+*   Connect to and control a presentation or remote playback, or extract data
+    from the application state of the presentation or remote playback.
+    
+One particular attack of concern is misconfigured or compromised routers that
+expose local network devices to the Internet.  This vector of attack has been
+used by remote parties to take control of printers and smart TVs by connecting
+to local network services that should normally be inaccessible from the
+Internet.
+
+### Denial of Service ### {#denial-of-service}
+
+Parties with access to the LAN may attempt to deny access to receivers by
+controllers, or vice versa.  For example, an active attacker my attempt to start
+a large number of QUIC connections on a receiver in an attempt to block
+legitimate connections or exhaust available resources on the presentation
+display.  They may also multicast spurious DNS-SD records in an attempt to
+exhaust the cache capacity for mDNS listeners.
+
+### Same-Origin Policy Violations ### {#same-origin-policy-violations}
+
+The Presentation API allows cross-origin communication between controlling pages
+and presentations with the consent of each origin (through their use of the
+API).  This is similar to cross-origin communication via {{Worker/postMessage}}.  The
+Open Screen Protocol does not convey origin information between controllers and
+receivers.
+
+The [=presentation ID=] carries some protection against unrestricted
+cross-origin access, but authentication of the parties connected by a
+{{PresentationConnection}} can be done at the application level.
+
+### Third Party Tracking ### {#third-party-tracking}
+
+The Open Screen Protocol does not give third party origins additional access to
+presentations or remote playback state.
+
+Open Screen Protocol Considerations {#security-privacy-questions}
+-----------------------------------
+
+### Personally Identifiable Information & High-Value Data ### {#personally-identifiable-information}
+
+The following data exchanged by the protocol can be personally identifiable and
+thus is high value data:
+
+1. Presentation URLs and availability results
+1. Presentation IDs
+1. Presentation connection IDs
+1. Presentation connection messages
+1. Remote playback URLs
+1. Remote playback commands and status messages
+
+Presentation display friendly names, model names, and capabilities, while not
+considered personally identifiable, is important to protect to preserve the
+integrity of the discovery process.
+
+The following data cannot be reasonably secured and should be considered public
+and untrusted data:
+
+1. IP addresses and ports used by the Open Screen Protocol.
+1. Data advertised through mDNS, including the certificate fingerprint and the 
+    metadata version.
+   
+### Cross Origin State Considerations ### {#cross-origin-state}
+
+Access to origin state across browsing sessions is possible through the
+Presentation API by reconnecting to a presentation that was started by a
+previous session. This sceanrio is addressed in
+[[PRESENTATION-API#cross-origin-access]].
+
+Presentation display availability and remote playback availability are states
+that may be available cross-origin depending on the user's network context.
+Exposure of this data to the Web is also discussed in
+[[PRESENTATION-API#personally-identifiable-information]] and
+[[REMOTE-PLAYBACK#personally-identifiable-information]].
+
+### Origin Access to Other Devices ### {#origin-access-devices}
+
+By design, the Open Screen Protocol allows access to presentation displays from
+the Web.  By implementing the protocol, these devices are knowingly making
+themselves available to the Web and should be designed accordingly.
+
+Below, we discuss mitigation steps to prevent malicious use of presentation
+displays.
+
+### Incognito Mode ### {#incognito-mode}
+
+The Open Screen Protocol does not distinguish between the user agent's normal
+browsing and incognito modes, and should operate identically regardless of which
+mode is using it.
+
+### Persistent State ### {#persistent-state}
+
+An implementation of the Open Screen Protocol is likely to persist the identity
+of controllers and receivers that have successfully completed
+[[#authentication]].  This may include the public key fingerprints, metadata
+versions, and metadata for those parties.
+
+However, this data is not normally exposed to the Web, only through the native
+UI of the user agent during the display selection or display authentication
+process.  It can be an implementation choice whether the user agent clears or
+retains this data when the user clears browsing data.
+
+TODO: File an issue to discuss
+
+### Other Considerations ### {#other-considerations}
+
+The Open Screen Protocol does not grant to the Web additional access to the
+following:
+
+* New script loading mechanisms
+* Access to the user's location
+* Access to device sensors
+* Access to the user's local computing environment
+* Control over the user agent's native UI
+* Security characteristics of the user agent
+
+Presentation API Considerations {#presentation-api-considerations}
+-------------------------------
 
 [[PRESENTATION-API#security-and-privacy-considerations][Presentation API
 Security and Privacy Considerations]] place these requirements on the Open
@@ -658,63 +799,109 @@ Screen Protocol:
     confidential, per the guidelines for messaging between presentation
     connections.
 
-Remote Playback API
--------------------
+The Open Screen Protocol addresses these considerations by:
+
+1. Requiring mutual authentication and a TLS-secured QUIC connection before
+     presentation URLs, IDs, or messages are exchanged.
+1. Adding explicit messages and connection IDs for individual
+     {{PresentationConnection|PresentationConnections}} so that controllers and
+     receivers can track the number of active connections.
+
+Remote Playback API Considerations {#remote-playback-considerations}
+----------------------------------
 
 The [[REMOTE-PLAYBACK#security-and-privacy-considerations][Remote Playback API
 Security and Privacy Considerations]] also state that messaging between local
 and remote playback devices should also be authenticated and confidential.
 
-Open Screen Protocol
---------------------
+This consideration is handled by requiring mutual authentication and a
+TLS-secured QUIC connection before any remote playback related messages are
+exchanged.
 
-Threat Models {#security-threat}
---------------------------------
-
-## Passive Attacks
-
-The Open Screen Protocol should assume that all parties that are able
-access the LAN, either through a wired connection or through WiFi, are able to
-observe all data flowing between Open Screen controllers and receivers.
-
-These parties will be able collect any data exposed through unencrypted
-messages, such as mDNS records and the QUIC handshake.
-
-## Active Attacks
-
-In addition, all parties with access to the LAN will be able to manipulate data
-exchanged between controllers and receivers and inititate QUIC connections.
-This can be used to attempt attacks such as:
-
-*   Impersonating a new receiver or one already known to the user, in an attempt
-    to convince the user to authenticate it as a trusted receiver.
-*   Connecting to a receiver and querying its capabilities, or attempting to
-    xconnect to a running presentation or remote playback.
-
-## Denial of Service
-
-
-Data to be secured {#security-data}
------------------------------------
-
-There are two kinds of data 
-
-1. Presentation URLs
-1. Presentation IDs
-1. Presentation connection messages
-1. Remote playback URLs
-1. Remote playback commands and status messages
-
-The following data cannot be reasonably secured and should be considered public
-and untrusted data:
-
-1. IP addresses and ports used by the Open Screen Protocol.
-1. Friendly names or other data advertised through mDNS.
-1. 
-
-Mitigation Strategies {#security-mitigation}
+Mitigation Strategies {#security-mitigations}
 --------------------------------------------
 
+### Local passive network attackers ### {#local-passive-mitigations}
+
+Local passive attackers may attempt to harvest data about user activities and
+device capabilties using the Open Screen Protocol.  The main strategy to address
+this is data minimization, by only exposing opaque public key fingerprints
+before user-mediated authentication takes place.
+
+Passive attackers may also attempt timing attacks to learn cryptographic the
+cryptographic parameters of the TLS 1.3 QUIC connection.
+
+TODO: Investigate mitigations for this.
+
+### Local active network attackers ### {#local-active-mitigations}
+
+Local active attackers may attempt to impersonate a presentation display the
+user would normally trust.  The [[#authentication]] step of the Open Screen
+Protocol prevents a man-in-the-middle from impersonating a controller or
+receiver, without knowledge of a shared secret.  However, it is possible for an
+attacker to impersonate an existing, trusted display or a newly discovered
+display that is not yet authenticated by convincing the user to authenticate it.
+
+This can be addressed through a combination of techniques.  The first is flagging:
+
+* Flag advertised displays whose friendly name, public key fingerprint, or
+    IP:port collide with an already trusted display.
+* Flag already-trusted displays whose metadata has changed.
+* Flag controllers or receivers that fail the authentication challenge a certain
+    number of times.
+  
+Flagging means that the user is notified, or in some cases they are required to
+re-authenticate to the presentation display to verify its identity.
+  
+The second is through management of the shared secret during mutual
+authentication:
+
+* Rotate the shared secret to prevent brute force attacks.
+* Use an increasing backoff to repond to authentication challenges, also to
+    prevent brute force attacks.
+* Use a cryptographically sound source of entropy to generate the shared secret.
+* Require the end user to manually type the shared secret - shown only the
+    display - to prevent the user from blindly clicking through this step.
+
+The active attacker may also attempt to disrupt data exchanged over the QUIC
+connection by injecting or modifying traffic.  These attacks should be mitigated
+by a correct implementation of TLS 1.3.
+
+TODO: Protect against TLS replay, esp. if we enable early data.
+
+### Remote active network attackers ### {#remote-active-mitigations}
+
+Unfortunately, we cannot rely on network devices to fully protect Open Screen
+controllers and receivers from traffic from the broader Internet.  Open Screen
+Protocol implementations that are only intended to work on the LAN should filter
+packets from non-local IP addresses.  Implementations can also use the ARP cache
+to detect attempts to spoof local network IP addresses.
+
+TODO: Fill in more details here.
+
+### Denial of service ### {#denial-of-service-mitigations}
+
+It will be difficult to completely prevent denial service of attacks that
+originate on the user's local area network.  Open Screen Protocol
+implementations can refuse new connections, rate limit the rate of messages from
+existing connections, or limit the number of mDNS records cached in an attempt
+to allow existing activities to continue in spite of such an attack.
+
+### Malicious input ### {#malicious-input-mitigations}
+
+Open Screen Protocol implementations should be robust against malicious input
+that attempts to compromise the target device by exploiting parsing
+vulnerabilities.
+
+CBOR is intended to be less vulnerable to such attacks relative to alternatives
+like JSON and XML.  Still, implementations should be thoroughly tested using
+approaches like [fuzz testing](https://en.wikipedia.org/wiki/Fuzzing).
+
+Where possible, Open Screen Protocol implementations (including the content
+rendering components) should use defense-in-depth techniques like
+[sandboxing](https://en.wikipedia.org/wiki/Sandbox_(computer_security)).
+to prevent vulnerabilities from gaining access to user data or leading to
+persistent exploits.
 
 Appendix A: Messages {#appendix-a}
 ====================

--- a/index.bs
+++ b/index.bs
@@ -446,17 +446,15 @@ For hkdf-of-scrypt-of-psk, the proof is calculated using the following steps:
 9. Let info be a CBOR-serialized certificate-fingerprint-pair object (CDDL
    defined in Appendix A) with the following values:
 
--   challenger-fingerprint: The certificate fingerprint of the
-    challenger, used in the QUIC crypto handshake during connection
-    establishment, as defined by [RFC 8122 section
-    5](https://tools.ietf.org/html/rfc8122#section-5).  It is the output using
-    sha-256 as the hash wihtout any hexadecimal encoding or prefixing.
+-   challenger-fingerprint: The result of running sha-256 on the
+    Distinguished Encoding Rules (DER) form (see
+    https://tools.ietf.org/html/rfc8122#section-5) of the certificate used by
+    the challenger in the QUIC crypto handshake during connection establishment.
 
--   responder-fingerprint: The certificate fingerprint of the
-    responder, obtained from the QUIC crypto handshake during connection
-    establishment, as defined by [RFC 8122 section
-    5](https://tools.ietf.org/html/rfc8122#section-5).  It is the output using
-    sha-256 as the hash wihtout any hexadecimal encoding or prefixing. 
+-   responder-fingerprint: The result of running sha-256 on the
+    Distinguished Encoding Rules (DER) form (see
+    https://tools.ietf.org/html/rfc8122#section-5) of the certificate used by
+    the responder in the QUIC crypto handshake during connection establishment.
 
 9. Let proof be the result of running
    [HKDF](https://tools.ietf.org/html/rfc5869) on scryptResult with 

--- a/index.bs
+++ b/index.bs
@@ -727,14 +727,14 @@ Playback API.
 Security and Privacy {#security-privacy}
 ====================
 
-The Open Screen Protocol allows two networked user agents to discover each other
+The Open Screen Protocol allows two networked agents to discover each other
 and exchange user and application data.  As such, its security and privacy
 considerations should be closely examined.  We first evaluate the protocol
 itself using the W3C [[SECURITY-PRIVACY-QUESTIONNAIRE|Security and Privacy
 Questionnaire]].  We then examine whether the security and privacy guidelines
 recommended by the [[PRESENTATION-API|Presentation API]] and the
 [[REMOTE-PLAYBACK|Remote Playback API]] are met.  Finally we discuss recommended
-mitigations that implementations can use to meet these security and privacy
+mitigations that agents can use to meet these security and privacy
 requirements.
 
 Threat Models {#threat-models}
@@ -744,39 +744,39 @@ Threat Models {#threat-models}
 
 The Open Screen Protocol should assume that all parties that are connected to
 the same LAN, either through a wired connection or through WiFi, are able to
-observe all data flowing between Open Screen controllers and receivers.
+observe all data flowing between Open Screen Protocol agents.
 
 These parties will be able collect any data exposed through unencrypted
-messages, such as mDNS records and the QUIC handshake.
+messages, such as mDNS records and the QUIC handshakes.
 
 These parties may attempt to learn cryptographic parameters by observing data
 flows on the QUIC connection, or by observing cryptographic timing.
 
 ### Active Network Attackers ### {#active-network-attackers}
 
-In addition, all parties connected to the LAN will be able to manipulate data
-exchanged between controllers and receivers.  They will be able to inject
-traffic into existing QUIC connections and attempt to inititate new QUIC
-connections.  These abilities can be used to attempt the following:
+Active attackers, such as compromised routers, will be able to manipulate data
+exchanged between agents.  They can inject traffic into existing QUIC
+connections and attempt to inititate new QUIC connections.  These abilities can
+be used to attempt the following:
 
-*   Impersonate a new receiver or one already trusted by the user, in an attempt
+*   Impersonate an agent or one already trusted by the user, in an attempt
     to convince the user to authenticate to it.
-*   Connect to a receiver and query its capabilities.
+*   Connect to an agent and query its capabilities.
 *   Connect to and control a presentation or remote playback, or extract data
     from the application state of the presentation or remote playback.
     
 One particular attack of concern is misconfigured or compromised routers that
-expose local network devices (such as Open Screen Protocol controllers and
-receivers) to the Internet.  This vector of attack has been used by malicious
-parties to take control of printers and smart TVs by connecting to local network
-services that would normally be inaccessible from the Internet.
+expose local network devices (such as Open Screen Protocol agents) to the
+Internet.  This vector of attack has been used by malicious parties to take
+control of printers and smart TVs by connecting to local network services that
+would normally be inaccessible from the Internet.
 
 ### Denial of Service ### {#denial-of-service}
 
-Parties connected to the LAN may attempt to deny access to Open Screen
-Protocol controllers and receivers.  For example, an attacker my attempt to open
-a large number of QUIC connections to a receiver in an attempt to block
-legitimate connections or exhaust the receiver's system resources.  They may
+Parties with connected to the LAN may attempt to deny access to Open Screen
+Protocol agents.  For example, an attacker my attempt to open
+a large number of QUIC connections to an agent in an attempt to block
+legitimate connections or exhaust the agent's system resources.  They may
 also multicast spurious DNS-SD records in an attempt to exhaust the cache
 capacity for mDNS listeners, or to get listeners to open a large number of bogus
 QUIC connections.
@@ -785,10 +785,10 @@ QUIC connections.
 
 The Presentation API allows cross-origin communication between controlling pages
 and presentations with the consent of each origin (through their use of the
-API).  This is similar to cross-origin communication via {{Window/postMessage()}}
-with a target origin of `*`.  However, the Presentation API does not convey
-source origin information with each message.  Therefore, the Open Screen
-Protocol does not convey origin information between controllers and receivers.
+API).  This is similar to cross-origin communication via
+{{Window/postMessage()}} with a target origin of `*`.  However, the Presentation
+API does not convey source origin information with each message.  Therefore, the
+Open Screen Protocol does not convey origin information between its agents.
 
 The [=presentation ID=] carries some protection against unrestricted
 cross-origin access; but, rigorous authentication of the parties connected by a
@@ -809,16 +809,20 @@ and/or high value data:
 1. Remote playback URLs
 1. Remote playback commands and status messages
 
-Presentation display friendly names, model names, and capabilities, while not
-considered personally identifiable, are important to protect to preserve the
-integrity of the discovery and authentication process.
+Presentation IDs are considered high value data because they can be used in
+conjunction with a Presentation URL to connect to a running presentation.
 
-The following data cannot be reasonably secured and should be considered public
-and untrusted data:
+Presentation display friendly names, model names, and capabilities, while not
+considered personally identifiable, are important to protect to prevent an
+attacker from changing them or substituting other values during the discovery
+and authentication process.
+
+The following data cannot be reasonably made confidential and should be
+considered public and untrusted data:
 
 1. IP addresses and ports used by the Open Screen Protocol.
-1. Data advertised through mDNS, including the certificate fingerprint and the 
-    metadata version.
+1. Data advertised through mDNS, including the display name prefix, the
+    certificate fingerprint, and the metadata version.
    
 ### Cross Origin State Considerations ### {#cross-origin-state}
 
@@ -845,20 +849,19 @@ Below, we discuss mitigation steps to prevent malicious use of these devices.
 ### Incognito Mode ### {#incognito-mode}
 
 The Open Screen Protocol does not distinguish between the user agent's normal
-browsing and incognito modes, and should operate identically regardless of which
-mode is in use.
+browsing and incognito modes, and agents that follow the specification
+behave identically regardless of which mode is in use.
 
 It's recommended that controllers use separate authentication contexts and QUIC
 connections for normal and incognito profiles from the same user agent instance.
-This prevents Open Screen receivers from correlating activity between a user's
-normal profile and their incognito profile.
+This prevents Open Screen receivers from correlating activity among a user's
+profiles (both normal and incognito).
 
 ### Persistent State ### {#persistent-state}
 
-An implementation of the Open Screen Protocol is likely to persist the identity
-of controllers and receivers that have successfully completed
-[[#authentication]].  This may include the public key fingerprints, metadata
-versions, and metadata for those parties.
+An agent is likely to persist the identity of agents that have successfully
+completed [[#authentication]].  This may include the public key fingerprints,
+metadata versions, and metadata for those parties.
 
 However, this data is not normally exposed to the Web, only through the native
 UI of the user agent during the display selection or display authentication
@@ -900,8 +903,8 @@ The Open Screen Protocol addresses these considerations by:
 1. Requiring mutual authentication and a TLS-secured QUIC connection before
      presentation URLs, IDs, or messages are exchanged.
 1. Adding explicit messages and connection IDs for individual
-     {{PresentationConnection|PresentationConnections}} so that controllers and
-     receivers can track the number of active connections.
+     {{PresentationConnection|PresentationConnections}} so that agents can track
+     the number of active connections.
 
 Remote Playback API Considerations {#remote-playback-considerations}
 ----------------------------------
@@ -933,19 +936,17 @@ Issue(130): [Security] Review attack and mitigation considerations for TLS 1.3
 
 Local active attackers may attempt to impersonate a presentation display the
 user would normally trust.  The [[#authentication]] step of the Open Screen
-Protocol prevents a man-in-the-middle from impersonating a controller or
-receiver, without knowledge of a shared secret.  However, it is possible for an
-attacker to impersonate an existing, trusted display or a newly discovered
-display that is not yet authenticated and try to convince the user to
-authenticate it.
+Protocol prevents a man-in-the-middle from impersonating an agent, without
+knowledge of a shared secret.  However, it is possible for an attacker to
+impersonate an existing, trusted display or a newly discovered display that is
+not yet authenticated and try to convince the user to authenticate it.
 
 This can be addressed through a combination of techniques.  The first is flagging:
 
 * Flag advertised displays whose friendly name, public key fingerprint, or
     IP:port collide with an already trusted display.
 * Flag already-trusted displays whose metadata has changed.
-* Flag controllers or receivers that fail the authentication challenge a certain
-    number of times.
+* Flag agents that fail the authentication challenge a certain number of times.
   
 Flagging means that the user is notified, or in some cases they are required to
 re-authenticate to the presentation display to verify its identity.
@@ -969,33 +970,33 @@ Issue(130): [Security] Review attack and mitigation considerations for TLS 1.3
 ### Remote active network attackers ### {#remote-active-mitigations}
 
 Unfortunately, we cannot rely on network devices to fully protect Open Screen
-controllers and receivers from traffic from the broader Internet.  Open Screen
-Protocol implementations that are only intended to work on the LAN should filter
-packets from non-local IP addresses.  Implementations can also use the ARP cache
-to detect attempts to spoof local network IP addresses.
+Protocol agents from traffic from the broader Internet.  Open Screen Protocol
+agents that are only intended to work on the LAN should filter packets
+from non-local IP addresses.  Agents can also use the ARP cache to
+detect attempts to spoof local network IP addresses.
 
 Issue(131): [Security] Mitigations for remote network attackers
 
 ### Denial of service ### {#denial-of-service-mitigations}
 
-It will be difficult to completely prevent denial of service attacks that
-originate on the user's local area network.  Open Screen Protocol
-implementations can refuse new connections, rate limit the rate of messages from
-existing connections, or limit the number of mDNS records cached in an attempt
-to allow existing activities to continue in spite of such an attack.
+It will be difficult to completely prevent denial service of attacks that
+originate on the user's local area network.  Open Screen Protocol agents can
+refuse new connections, rate limit the rate of messages from existing
+connections, or limit the number of mDNS records cached from a specific
+responder in an attempt to allow existing activities to continue in spite of
+such an attack.
 
 ### Malicious input ### {#malicious-input-mitigations}
 
-Open Screen Protocol implementations should be robust against malicious input
-that attempts to compromise the target device by exploiting parsing
-vulnerabilities.
+Open Screen Protocol agents should be robust against malicious input that
+attempts to compromise the target device by exploiting parsing vulnerabilities.
 
 CBOR is intended to be less vulnerable to such attacks relative to alternatives
-like JSON and XML.  Still, implementations should be thoroughly tested using
-approaches like [fuzz testing](https://en.wikipedia.org/wiki/Fuzzing).
+like JSON and XML.  Still, agents should be thoroughly tested using approaches
+like [fuzz testing](https://en.wikipedia.org/wiki/Fuzzing).
 
-Where possible, Open Screen Protocol implementations (including the content
-rendering components) should use defense-in-depth techniques like <a
+Where possible, Open Screen Protocol agents (including the content rendering
+components) should use defense-in-depth techniques like <a
 href="https://en.wikipedia.org/wiki/Sandbox_(computer_security)">sandboxing</a>
 to prevent vulnerabilities from gaining access to user data or leading to
 persistent exploits.

--- a/index.bs
+++ b/index.bs
@@ -852,10 +852,10 @@ The Open Screen Protocol does not distinguish between the user agent's normal
 browsing and incognito modes, and agents that follow the specification
 behave identically regardless of which mode is in use.
 
-It's recommended that controllers use separate authentication contexts and QUIC
+It's recommended that user agents use separate authentication contexts and QUIC
 connections for normal and incognito profiles from the same user agent instance.
-This prevents Open Screen receivers from correlating activity among a user's
-profiles (both normal and incognito).
+This prevents Open Screen agents from correlating activity among profiles
+belonging to the same user (both normal and incognito).
 
 ### Persistent State ### {#persistent-state}
 
@@ -892,9 +892,10 @@ requirements on the Open Screen Protocol:
 1.  Presentation URLs and presentation IDs should remain private among the
     parties that are allowed to connect to a presentation, per the
     cross-origin access guidelines.
-1.  Controllers and receivers should be notified when multiple connections have
-    been made to a presentation, per the user interface guidelines.
-1.  Messaging between presentations and controllers should be authenticated and
+1.  Controllers and receivers should be notified when connections representing
+    multiple user agent profiles have been made to a presentation, per the user
+    interface guidelines.
+1.  Messaging between controllers and receivers should be authenticated and
     confidential, per the guidelines for messaging between presentation
     connections.
 
@@ -927,7 +928,7 @@ device capabilties using the Open Screen Protocol.  The main strategy to address
 this is data minimization, by only exposing opaque public key fingerprints
 before user-mediated authentication takes place.
 
-Passive attackers may also attempt timing attacks to learn cryptographic the
+Passive attackers may also attempt timing attacks to learn the
 cryptographic parameters of the TLS 1.3 QUIC connection.
 
 Issue(130): [Security] Review attack and mitigation considerations for TLS 1.3
@@ -943,8 +944,10 @@ not yet authenticated and try to convince the user to authenticate it.
 
 This can be addressed through a combination of techniques.  The first is flagging:
 
-* Flag advertised displays whose friendly name, public key fingerprint, or
-    IP:port collide with an already trusted display.
+* Flag an advertised display whose public key fingerprint collides with that
+    from an already-trusted display that is concurrently being advertised.
+* Flag an advertised display whose friendly name differs from the one previously
+    advertised under a public key fingerprint.
 * Flag already-trusted displays whose metadata has changed.
 * Flag agents that fail the authentication challenge a certain number of times.
   

--- a/index.bs
+++ b/index.bs
@@ -702,7 +702,7 @@ The [=presentation ID=] carries some protection against unrestricted
 cross-origin access; but, rigorous authentication of the parties connected by a
 {{PresentationConnection}} must be done at the application level.
 
-Open Screen Protocol Considerations {#security-privacy-questions}
+Open Screen Protocol Security and Privacy Considerations {#security-privacy-questions}
 -----------------------------------
 
 ### Personally Identifiable Information & High-Value Data ### {#personally-identifiable-information}

--- a/index.bs
+++ b/index.bs
@@ -408,25 +408,43 @@ The responder replies with an authentication-response message with the following
 -   result:  If the responder was able to calculate proof of possession of the
     shared secret, and if it failed, why it failed.
 
--   proof: The result of running
-    [HKDF](https://tools.ietf.org/html/rfc5869) on the result of running
-    [scrypt](https://tools.ietf.org/html/rfc7914) on the shared secret.  For
-    scrypt, the cost parameter (N) used is the 2 to the power of the cost from
-    the authentication-request message, the block size (r) is 8, the
-    parallelization parameter (p) is 1, and the key length derived is 32.  For
-    HKDF, both the extract and expand steps are used, the hash function used is
-    sha-256, the salt used is the salt from the authentication-request message,
-    the application-specific info is a serialized certificate-fingerprint-pair
-    object (defined below), and the length of the output key matrial (L) is 32.
+-   proof: The result of running the authentication mechanism.  The steps for
+    hkdf-of-scrypt-of-psk are described below.
 
-Note: the values of 32 above (for salt length, scrypt output key length, and
-HKDF output key material length) are based on the output size of sha-256.  If a
-different hash mechanism is used in the future, these values should be updated as
-well.
+The challenger verifies the proof and sends the responder an
+authentication-result message with the following values:
 
-The certificate-fingerprint-pair object used as application-specific info above
-is serialized as CBOR (without the type or length prefix of messages in a QUIC
-stream) and contains the following values:
+-   result:  If the challenger was able to authenticate the responder or not,
+    and if not, why not.
+
+The challenger must limit the time the responder has to send a response to 60
+seconds (to avoid the possibility of brute-force attacks.)
+
+
+For hkdf-of-scrypt-of-psk, the proof is calculated using the following steps:
+
+1. Let secret be the pre-shared secret.
+
+2. Let N be 2 to the power of of the cost from the authentication-request
+   message.
+
+3. Let r be 8.
+
+4. Let p be 1.
+
+5. Let keyLength be 32.
+
+6. Let scryptResult be the result of running
+   [scrypt](https://tools.ietf.org/html/rfc7914) on secret with cost parameter N,
+   block size r, parallelization parameter p, and derived key length of
+   keyLength.
+
+7. Let hashFunction be sha-256.
+
+8. Let salt be the salt from the authentication-request message.
+
+9. Let info be a CBOR-serialized certificate-fingerprint-pair object (CDDL
+   defined in Appendix A) with the following values:
 
 -   challenger-fingerprint: The certificate fingerprint of the
     challenger, used in the QUIC crypto handshake during connection
@@ -440,18 +458,19 @@ stream) and contains the following values:
     5](https://tools.ietf.org/html/rfc8122#section-5).  It is the output using
     sha-256 as the hash wihtout any hexadecimal encoding or prefixing. 
 
+9. Let proof be the result of running
+   [HKDF](https://tools.ietf.org/html/rfc5869) on scryptResult with 
+   both the extract and expand steps, hash function hashFunction,
+   application-specific info, and output key length keyLength.
+
 To verify that the responder's proof is correct, the challenger makes the same
 calculation of the proof and compares the result. If the results are the same,
 the challenger considers the responder authenticated, and considers it
-unauthenticated otherwise.  In either case, the challenger sends the responder an
-authentication-result message with the following values:
+unauthenticated otherwise.  
 
--   result:  If the challenger was able to authenticate the responder or not,
-    and if not, why not.
-
-The challenger must limit the time the responder has to send a response to 60
-seconds (to avoid the possibility of brute-force attacks.)
-
+Note: the values of 32 above (for salt length, keyLength) are based on the
+output size of sha-256.  If a different hash mechanism is used in the future,
+these values should be updated as well.
 
 
 Control Protocols {#control-protocols}

--- a/index.bs
+++ b/index.bs
@@ -862,7 +862,7 @@ The second is through management of the shared secret during mutual
 authentication:
 
 * Rotate the shared secret to prevent brute force attacks.
-* Use an increasing backoff to repond to authentication challenges, also to
+* Use an increasing backoff to respond to authentication challenges, also to
     prevent brute force attacks.
 * Use a cryptographically sound source of entropy to generate the shared secret.
 * Require the end user to manually type the shared secret - shown only the

--- a/index.bs
+++ b/index.bs
@@ -426,7 +426,7 @@ For hkdf-of-scrypt-of-psk, the proof is calculated using the following steps:
 1. Let secret be the pre-shared secret.
 
 2. Let N be 2 to the power of of the cost from the authentication-request
-   message.
+     message.
 
 3. Let r be 8.
 
@@ -435,16 +435,16 @@ For hkdf-of-scrypt-of-psk, the proof is calculated using the following steps:
 5. Let keyLength be 32.
 
 6. Let scryptResult be the result of running
-   [scrypt](https://tools.ietf.org/html/rfc7914) on secret with cost parameter N,
-   block size r, parallelization parameter p, and derived key length of
-   keyLength.
+     [scrypt](https://tools.ietf.org/html/rfc7914) on secret with cost parameter N,
+     block size r, parallelization parameter p, and derived key length of
+     keyLength.
 
 7. Let hashFunction be sha-256.
 
 8. Let salt be the salt from the authentication-request message.
 
 9. Let info be a CBOR-serialized certificate-fingerprint-pair object (CDDL
-   defined in Appendix A) with the following values:
+     defined in Appendix A) with the following values:
 
 -   challenger-fingerprint: The result of running sha-256 on the
     Distinguished Encoding Rules (DER) form (see
@@ -457,9 +457,9 @@ For hkdf-of-scrypt-of-psk, the proof is calculated using the following steps:
     the responder in the QUIC crypto handshake during connection establishment.
 
 9. Let proof be the result of running
-   [HKDF](https://tools.ietf.org/html/rfc5869) on scryptResult with 
-   both the extract and expand steps, hash function hashFunction,
-   application-specific info, and output key length keyLength.
+     [\HKDF](https://tools.ietf.org/html/rfc5869) on scryptResult with 
+     both the extract and expand steps, hash function hashFunction,
+     application-specific info, and output key length keyLength.
 
 To verify that the responder's proof is correct, the challenger makes the same
 calculation of the proof and compares the result. If the results are the same,

--- a/index.bs
+++ b/index.bs
@@ -268,16 +268,83 @@ Playback API.
 Security and Privacy {#security}
 ================================
 
-Issue(13): Describe security architecture.
+The Open Screen Protocol should, at a minimum, conform to the security and
+privacy guidelines recommended by the [[PRESENTATION-API][Presentation API]] and
+the [[REMOTE-PLAYBACK][Remote Playback API]].
+
+In addition, the Open Screen Protocol itself has additional security and privacy
+considerations.
+
+Presentation API Security and Privacy
+-------------------------------------
+
+The [[PRESENTATION-API#security-and-privacy-considerations][Presentation API
+Security and Privacy Considerations]] place these requirements on the Open
+Screen Protocol:
+
+1.  Presentation URLs and presentation IDs should remain private among the
+    parties that are allowed to connect to a presentation, per the
+    cross-origin access guidelines.
+1.  Controllers and recievers should be notified when multiple connections have
+    been made to a presentation, per the user interface guidelines.
+1.  Messaging between presentations and controllers should be authenticated and
+    confidential, per the guidelines for messaging between presentation
+    connections.
+
+Remote Playback API Security and Privacy
+----------------------------------------
+
+The [[REMOTE-PLAYBACK#security-and-privacy-considerations][Remote Playback API
+Security and Privacy Considerations]] also state that messaging between local
+and remote playback devices should also be authenticated and confidential.
+
+Threat Models {#security-threat}
+--------------------------------
+
+## Passive Attacks
+
+The Open Screen Protocol should assume that all parties that are able
+access the LAN, either through a wired connection or through WiFi, are able to
+observe all data flowing between Open Screen controllers and receivers.
+
+These parties will be able collect any data exposed through unencrypted
+messages, such as mDNS records and the QUIC handshake.
+
+## Active Attacks
+
+In addition, all parties with access to the LAN will be able to manipulate data
+exchanged between controllers and receivers and inititate QUIC connections.
+This can be used to attempt attacks such as:
+
+*   Impersonating a new receiver or one already known to the user, in an attempt
+    to convince the user to authenticate it as a trusted receiver.
+*   Connecting to a receiver and querying its capabilities, or attempting to
+    connect to a running presentation or remote playback.
+
+## Denial of Service
+
 
 Data to be secured {#security-data}
 -----------------------------------
 
-Threat model {#security-threat}
--------------------------------
+There are two kinds of data 
 
-Mitigations and defenses {#security-defenses}
----------------------------------------------
+1. Presentation URLs
+1. Presentation IDs
+1. Presentation connection messages
+1. Remote playback URLs
+1. Remote playback commands and status messages
+
+The following data cannot be reasonably secured and should be considered public
+and untrusted data:
+
+1. IP addresses and ports used by the Open Screen Protocol.
+1. Friendly names or other data advertised through mDNS.
+1. 
+
+Mitigation Strategies {#security-mitigation}
+--------------------------------------------
+
 
 
 

--- a/index.bs
+++ b/index.bs
@@ -393,7 +393,9 @@ The challenger sends an authentication-request message with the following values
     defines the mechanism hkdf-of-scrypt-of-psk but this field gives a place for
     other mechanisms to be specified.
 
--   salt: 32 random bytes (which need not be kept secret). 
+-   salt: 32 random bytes.  This salt is used in HKDF, so see
+    https://tools.ietf.org/html/rfc5869#section-3.1 for more details on how this
+    value should be generated.
 
 -   cost: log base 2 of the cost parameter (N) for scrypt defined in [RFC
     7914 section 2](https://tools.ietf.org/html/rfc7914#section-2).  It must be

--- a/index.bs
+++ b/index.bs
@@ -681,7 +681,7 @@ services that would normally be inaccessible from the Internet.
 
 ### Denial of Service ### {#denial-of-service}
 
-Parties with connected to the LAN may attempt to deny access to Open Screen
+Parties connected to the LAN may attempt to deny access to Open Screen
 Protocol controllers and receivers.  For example, an attacker my attempt to open
 a large number of QUIC connections to a receiver in an attempt to block
 legitimate connections or exhaust the receiver's system resources.  They may

--- a/index.bs
+++ b/index.bs
@@ -378,9 +378,9 @@ Authentication {#authentication}
 
 In order for one agent (the challenger) to authenticate another (the responder),
 the challenger may send an authentication-request message and expect an
-authentication-response message to best sent back from the responder.  To
+authentication-response message to be sent back from the responder.  To
 mutually authenticate, this mechanism is used twice, once by each side acting as
-the challenger.  This mechanism assumes the agents share a low-entry secret,
+the challenger.  This mechanism assumes the agents share a low-entropy secret,
 such as a number or a short password that could be entered by a user on a
 keyboard or TV remote control.
 

--- a/index.bs
+++ b/index.bs
@@ -797,7 +797,7 @@ requirements on the Open Screen Protocol:
 1.  Presentation URLs and presentation IDs should remain private among the
     parties that are allowed to connect to a presentation, per the
     cross-origin access guidelines.
-1.  Controllers and recievers should be notified when multiple connections have
+1.  Controllers and receivers should be notified when multiple connections have
     been made to a presentation, per the user interface guidelines.
 1.  Messaging between presentations and controllers should be authenticated and
     confidential, per the guidelines for messaging between presentation

--- a/index.bs
+++ b/index.bs
@@ -865,7 +865,7 @@ authentication:
 * Use an increasing backoff to respond to authentication challenges, also to
     prevent brute force attacks.
 * Use a cryptographically sound source of entropy to generate the shared secret.
-* Require the end user to manually type the shared secret - shown only the
+* Require the end user to manually type the shared secret - shown only on the
     display - to prevent the user from blindly clicking through this step.
 
 The active attacker may also attempt to disrupt data exchanged over the QUIC

--- a/index.bs
+++ b/index.bs
@@ -886,7 +886,7 @@ Issue(131): [Security] Mitigations for remote network attackers
 
 ### Denial of service ### {#denial-of-service-mitigations}
 
-It will be difficult to completely prevent denial service of attacks that
+It will be difficult to completely prevent denial of service attacks that
 originate on the user's local area network.  Open Screen Protocol
 implementations can refuse new connections, rate limit the rate of messages from
 existing connections, or limit the number of mDNS records cached in an attempt

--- a/index.bs
+++ b/index.bs
@@ -718,7 +718,7 @@ and/or high value data:
 1. Remote playback commands and status messages
 
 Presentation display friendly names, model names, and capabilities, while not
-considered personally identifiable, is important to protect to preserve the
+considered personally identifiable, are important to protect to preserve the
 integrity of the discovery and authentication process.
 
 The following data cannot be reasonably secured and should be considered public

--- a/index.bs
+++ b/index.bs
@@ -942,22 +942,28 @@ knowledge of a shared secret.  However, it is possible for an attacker to
 impersonate an existing, trusted display or a newly discovered display that is
 not yet authenticated and try to convince the user to authenticate it.
 
-This can be addressed through a combination of techniques.  The first is flagging:
+This can be addressed through a combination of techniques.  The first is
+detecting and flagging attempts at impersonation; a few of the situations that
+should be flagged include:
 
-* Flag an advertised display whose public key fingerprint collides with that
-    from an already-trusted display that is concurrently being advertised.
-* Flag an advertised display whose friendly name differs from the one previously
-    advertised under a public key fingerprint.
-* Flag already-trusted displays whose metadata has changed.
-* Flag agents that fail the authentication challenge a certain number of times.
+* Untrusted agents whose public key fingerprint collides with that from an
+    already-trusted agent that is concurrently being advertised.
+* Untrusted agents whose friendly name differs from the one previously
+    advertised under a given public key fingerprint.
+* Untrusted agents that fail the authentication challenge a certain number of times.
+* Untrusted agents that advertise a friendly name that is similar to that from an
+    already-trusted agent.
+* Already-trusted agents whose metadata provided through the `agent-info`
+    message has changed.
   
-Flagging means that the user is notified, or in some cases they are required to
-re-authenticate to the presentation display to verify its identity.
+Flagging means that the user is notified of the attempt at impersonation.  In
+the last case, the user should be required to re-authenticate to the
+already-trusted agent to verify its identity.
   
-The second is through management of the shared secret during mutual
+The second is through management of the low-entropy secret during mutual
 authentication:
 
-* Rotate the shared secret to prevent brute force attacks.
+* Rotate the low-entropy secret to prevent brute force attacks.
 * Use an increasing backoff to respond to authentication challenges, also to
     prevent brute force attacks.
 * Use a cryptographically sound source of entropy to generate the shared secret.
@@ -973,10 +979,9 @@ Issue(130): [Security] Review attack and mitigation considerations for TLS 1.3
 ### Remote active network attackers ### {#remote-active-mitigations}
 
 Unfortunately, we cannot rely on network devices to fully protect Open Screen
-Protocol agents from traffic from the broader Internet.  Open Screen Protocol
-agents that are only intended to work on the LAN should filter packets
-from non-local IP addresses.  Agents can also use the ARP cache to
-detect attempts to spoof local network IP addresses.
+Protocol agents, because a misconfigured firewall or NAT could expose a
+LAN-connected agent to the broader Internet.  Open Screen Protocol agents
+should be secure against attack from any Inernet host.
 
 Issue(131): [Security] Mitigations for remote network attackers
 
@@ -984,10 +989,9 @@ Issue(131): [Security] Mitigations for remote network attackers
 
 It will be difficult to completely prevent denial service of attacks that
 originate on the user's local area network.  Open Screen Protocol agents can
-refuse new connections, rate limit the rate of messages from existing
-connections, or limit the number of mDNS records cached from a specific
-responder in an attempt to allow existing activities to continue in spite of
-such an attack.
+refuse new connections, close connections that receive too many messages, or
+limit the number of mDNS records cached from a specific responder in an attempt
+to allow existing activities to continue in spite of such an attack.
 
 ### Malicious input ### {#malicious-input-mitigations}
 

--- a/index.bs
+++ b/index.bs
@@ -319,7 +319,7 @@ This can be used to attempt attacks such as:
 *   Impersonating a new receiver or one already known to the user, in an attempt
     to convince the user to authenticate it as a trusted receiver.
 *   Connecting to a receiver and querying its capabilities, or attempting to
-    connect to a running presentation or remote playback.
+    xconnect to a running presentation or remote playback.
 
 ## Denial of Service
 

--- a/index.bs
+++ b/index.bs
@@ -642,13 +642,13 @@ The Open Screen Protocol should, at a minimum, conform to the security and
 privacy guidelines recommended by the [[PRESENTATION-API][Presentation API]] and
 the [[REMOTE-PLAYBACK][Remote Playback API]].
 
-In addition, the Open Screen Protocol itself has additional security and privacy
+In addition, the Open Screen Protocol itself adds additional security and privacy
 considerations.
 
-Presentation API Security and Privacy
--------------------------------------
+Presentation API
+----------------
 
-The [[PRESENTATION-API#security-and-privacy-considerations][Presentation API
+[[PRESENTATION-API#security-and-privacy-considerations][Presentation API
 Security and Privacy Considerations]] place these requirements on the Open
 Screen Protocol:
 
@@ -661,12 +661,15 @@ Screen Protocol:
     confidential, per the guidelines for messaging between presentation
     connections.
 
-Remote Playback API Security and Privacy
-----------------------------------------
+Remote Playback API
+-------------------
 
 The [[REMOTE-PLAYBACK#security-and-privacy-considerations][Remote Playback API
 Security and Privacy Considerations]] also state that messaging between local
 and remote playback devices should also be authenticated and confidential.
+
+Open Screen Protocol
+--------------------
 
 Threat Models {#security-threat}
 --------------------------------

--- a/index.bs
+++ b/index.bs
@@ -638,9 +638,12 @@ Security and Privacy {#security-privacy}
 The Open Screen Protocol allows two networked user agents to discover each other
 and exchange user and application data.  As such, its security and privacy
 considerations should be closely examined.  We first evaluate the protocol
-itself using the W3C [[SECURITY-PRIVACY-QUESTIONNAIRE]].  We then examine
-whether the security and privacy guidelines recommended by the
-[[PRESENTATION-API]] and the [[REMOTE-PLAYBACK] are met.
+itself using the W3C [[SECURITY-PRIVACY-QUESTIONNAIRE|Security and Privacy
+Questionnaire]].  We then examine whether the security and privacy guidelines
+recommended by the [[PRESENTATION-API|Presentation API]] and the
+[[REMOTE-PLAYBACK|Remote Playback API]] are met.  Finally we discuss recommended
+mitigations that implementations can use to meet these security and privacy
+requirements.
 
 Threat Models {#threat-models}
 --------------------------------
@@ -648,9 +651,8 @@ Threat Models {#threat-models}
 ### Passive Network Attackers ### {#passive-network-attackers}
 
 The Open Screen Protocol should assume that all parties that are connected to
-the same LAN as the user agents, either through a wired connection or through
-WiFi, are able to observe all data flowing between Open Screen controllers and
-receivers.
+the same LAN, either through a wired connection or through WiFi, are able to
+observe all data flowing between Open Screen controllers and receivers.
 
 These parties will be able collect any data exposed through unencrypted
 messages, such as mDNS records and the QUIC handshake.
@@ -660,10 +662,10 @@ flows on the QUIC connection, or by observing cryptographic timing.
 
 ### Active Network Attackers ### {#active-network-attackers}
 
-In addition, all parties with access to the LAN will be able to manipulate data
+In addition, all parties connected to the LAN will be able to manipulate data
 exchanged between controllers and receivers.  They will be able to inject
-traffic into both parties and attempt to inititate new QUIC connections.  These abilities
-can be used to attempt the following:
+traffic into existing QUIC connections and attempt to inititate new QUIC
+connections.  These abilities can be used to attempt the following:
 
 *   Impersonate a new receiver or one already trusted by the user, in an attempt
     to convince the user to authenticate to it.
@@ -672,44 +674,41 @@ can be used to attempt the following:
     from the application state of the presentation or remote playback.
     
 One particular attack of concern is misconfigured or compromised routers that
-expose local network devices to the Internet.  This vector of attack has been
-used by remote parties to take control of printers and smart TVs by connecting
-to local network services that should normally be inaccessible from the
-Internet.
+expose local network devices (such as Open Screen Protocol controllers and
+receivers) to the Internet.  This vector of attack has been used by malicious
+parties to take control of printers and smart TVs by connecting to local network
+services that would normally be inaccessible from the Internet.
 
 ### Denial of Service ### {#denial-of-service}
 
-Parties with access to the LAN may attempt to deny access to receivers by
-controllers, or vice versa.  For example, an active attacker my attempt to start
-a large number of QUIC connections on a receiver in an attempt to block
-legitimate connections or exhaust available resources on the presentation
-display.  They may also multicast spurious DNS-SD records in an attempt to
-exhaust the cache capacity for mDNS listeners.
+Parties with connected to the LAN may attempt to deny access to Open Screen
+Protocol controllers and receivers.  For example, an attacker my attempt to open
+a large number of QUIC connections to a receiver in an attempt to block
+legitimate connections or exhaust the receiver's system resources.  They may
+also multicast spurious DNS-SD records in an attempt to exhaust the cache
+capacity for mDNS listeners, or to get listeners to open a large number of bogus
+QUIC connections.
 
 ### Same-Origin Policy Violations ### {#same-origin-policy-violations}
 
 The Presentation API allows cross-origin communication between controlling pages
 and presentations with the consent of each origin (through their use of the
-API).  This is similar to cross-origin communication via {{Worker/postMessage}}.  The
-Open Screen Protocol does not convey origin information between controllers and
-receivers.
+API).  This is similar to cross-origin communication via {{Window/postMessage()}}
+with a target origin of `*`.  However, the Presentation API does not convey
+source origin information with each message.  Therefore, the Open Screen
+Protocol does not convey origin information between controllers and receivers.
 
 The [=presentation ID=] carries some protection against unrestricted
-cross-origin access, but authentication of the parties connected by a
-{{PresentationConnection}} can be done at the application level.
-
-### Third Party Tracking ### {#third-party-tracking}
-
-The Open Screen Protocol does not give third party origins additional access to
-presentations or remote playback state.
+cross-origin access; but, rigorous authentication of the parties connected by a
+{{PresentationConnection}} must be done at the application level.
 
 Open Screen Protocol Considerations {#security-privacy-questions}
 -----------------------------------
 
 ### Personally Identifiable Information & High-Value Data ### {#personally-identifiable-information}
 
-The following data exchanged by the protocol can be personally identifiable and
-thus is high value data:
+The following data exchanged by the protocol can be personally identifiable
+and/or high value data:
 
 1. Presentation URLs and availability results
 1. Presentation IDs
@@ -720,7 +719,7 @@ thus is high value data:
 
 Presentation display friendly names, model names, and capabilities, while not
 considered personally identifiable, is important to protect to preserve the
-integrity of the discovery process.
+integrity of the discovery and authentication process.
 
 The following data cannot be reasonably secured and should be considered public
 and untrusted data:
@@ -733,29 +732,34 @@ and untrusted data:
 
 Access to origin state across browsing sessions is possible through the
 Presentation API by reconnecting to a presentation that was started by a
-previous session. This sceanrio is addressed in
+previous session. This scenario is addressed in
 [[PRESENTATION-API#cross-origin-access]].
 
-Presentation display availability and remote playback availability are states
-that may be available cross-origin depending on the user's network context.
-Exposure of this data to the Web is also discussed in
+Presentation display availability and remote playback device availability are
+states that are available cross-origin depending on the user's network
+context.  Exposure of this data to the Web is also discussed in
 [[PRESENTATION-API#personally-identifiable-information]] and
 [[REMOTE-PLAYBACK#personally-identifiable-information]].
 
 ### Origin Access to Other Devices ### {#origin-access-devices}
 
-By design, the Open Screen Protocol allows access to presentation displays from
-the Web.  By implementing the protocol, these devices are knowingly making
-themselves available to the Web and should be designed accordingly.
+By design, the Open Screen Protocol allows access to presentation displays and
+remote playback devices from the Web.  By implementing the protocol, these
+devices are knowingly making themselves available to the Web and should be
+designed accordingly.
 
-Below, we discuss mitigation steps to prevent malicious use of presentation
-displays.
+Below, we discuss mitigation steps to prevent malicious use of these devices.
 
 ### Incognito Mode ### {#incognito-mode}
 
 The Open Screen Protocol does not distinguish between the user agent's normal
 browsing and incognito modes, and should operate identically regardless of which
-mode is using it.
+mode is in use.
+
+It's recommended that controllers use separate authentication contexts and QUIC
+connections for normal and incognito profiles from the same user agent instance.
+This prevents Open Screen receivers from correlating activity between a user's
+normal profile and their incognito profile.
 
 ### Persistent State ### {#persistent-state}
 
@@ -769,7 +773,8 @@ UI of the user agent during the display selection or display authentication
 process.  It can be an implementation choice whether the user agent clears or
 retains this data when the user clears browsing data.
 
-TODO: File an issue to discuss
+Issue(132): [Privacy] Fate of metadata / authentication history when clearing
+browsing data
 
 ### Other Considerations ### {#other-considerations}
 
@@ -786,9 +791,8 @@ following:
 Presentation API Considerations {#presentation-api-considerations}
 -------------------------------
 
-[[PRESENTATION-API#security-and-privacy-considerations][Presentation API
-Security and Privacy Considerations]] place these requirements on the Open
-Screen Protocol:
+[[PRESENTATION-API#security-and-privacy-considerations]] place these
+requirements on the Open Screen Protocol:
 
 1.  Presentation URLs and presentation IDs should remain private among the
     parties that are allowed to connect to a presentation, per the
@@ -810,9 +814,9 @@ The Open Screen Protocol addresses these considerations by:
 Remote Playback API Considerations {#remote-playback-considerations}
 ----------------------------------
 
-The [[REMOTE-PLAYBACK#security-and-privacy-considerations][Remote Playback API
-Security and Privacy Considerations]] also state that messaging between local
-and remote playback devices should also be authenticated and confidential.
+The [[REMOTE-PLAYBACK#security-and-privacy-considerations]] also state that
+messaging between local and remote playback devices should also be authenticated
+and confidential.
 
 This consideration is handled by requiring mutual authentication and a
 TLS-secured QUIC connection before any remote playback related messages are
@@ -831,7 +835,7 @@ before user-mediated authentication takes place.
 Passive attackers may also attempt timing attacks to learn cryptographic the
 cryptographic parameters of the TLS 1.3 QUIC connection.
 
-TODO: Investigate mitigations for this.
+Issue(130): [Security] Review attack and mitigation considerations for TLS 1.3
 
 ### Local active network attackers ### {#local-active-mitigations}
 
@@ -840,7 +844,8 @@ user would normally trust.  The [[#authentication]] step of the Open Screen
 Protocol prevents a man-in-the-middle from impersonating a controller or
 receiver, without knowledge of a shared secret.  However, it is possible for an
 attacker to impersonate an existing, trusted display or a newly discovered
-display that is not yet authenticated by convincing the user to authenticate it.
+display that is not yet authenticated and try to convince the user to
+authenticate it.
 
 This can be addressed through a combination of techniques.  The first is flagging:
 
@@ -867,7 +872,7 @@ The active attacker may also attempt to disrupt data exchanged over the QUIC
 connection by injecting or modifying traffic.  These attacks should be mitigated
 by a correct implementation of TLS 1.3.
 
-TODO: Protect against TLS replay, esp. if we enable early data.
+Issue(130): [Security] Review attack and mitigation considerations for TLS 1.3
 
 ### Remote active network attackers ### {#remote-active-mitigations}
 
@@ -877,7 +882,7 @@ Protocol implementations that are only intended to work on the LAN should filter
 packets from non-local IP addresses.  Implementations can also use the ARP cache
 to detect attempts to spoof local network IP addresses.
 
-TODO: Fill in more details here.
+Issue(131): [Security] Mitigations for remote network attackers
 
 ### Denial of service ### {#denial-of-service-mitigations}
 
@@ -898,8 +903,8 @@ like JSON and XML.  Still, implementations should be thoroughly tested using
 approaches like [fuzz testing](https://en.wikipedia.org/wiki/Fuzzing).
 
 Where possible, Open Screen Protocol implementations (including the content
-rendering components) should use defense-in-depth techniques like
-[sandboxing](https://en.wikipedia.org/wiki/Sandbox_(computer_security)).
+rendering components) should use defense-in-depth techniques like <a
+href="https://en.wikipedia.org/wiki/Sandbox_(computer_security)">sandboxing</a>
 to prevent vulnerabilities from gaining access to user data or leading to
 persistent exploits.
 

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version a816d78e14132d4d4d2ee44ccaf1b8bc90ac75d5" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="77585e07f782e3b3875243939fc66e52e76efd96" name="document-revision">
+  <meta content="366fde95a501e55aff3123d8c2117a22e77b76a3" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1403,7 +1403,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-20">20 September 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-02">2 November 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1430,34 +1430,38 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <nav data-fill-with="table-of-contents" id="toc">
    <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
    <ol class="toc" role="directory">
-    <li><a href="#status"><span class="secno">1</span> <span class="content">Status of this Document</span></a>
     <li>
-     <a href="#introduction"><span class="secno">2</span> <span class="content">Introduction</span></a>
+     <a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
      <ol class="toc">
-      <li><a href="#terminology"><span class="secno">2.1</span> <span class="content">Terminology</span></a>
+      <li><a href="#terminology"><span class="secno">1.1</span> <span class="content">Terminology</span></a>
      </ol>
     <li>
-     <a href="#requirements"><span class="secno">3</span> <span class="content">Requirements</span></a>
+     <a href="#requirements"><span class="secno">2</span> <span class="content">Requirements</span></a>
      <ol class="toc">
-      <li><a href="#requirements-presentation-api"><span class="secno">3.1</span> <span class="content">Presentation API Requirements</span></a>
-      <li><a href="#requirements-remote-playback"><span class="secno">3.2</span> <span class="content">Remote Playback API Requirements</span></a>
-      <li><a href="#requirements-non-functional"><span class="secno">3.3</span> <span class="content">Non-Functional Requirements</span></a>
+      <li><a href="#requirements-presentation-api"><span class="secno">2.1</span> <span class="content">Presentation API Requirements</span></a>
+      <li><a href="#requirements-remote-playback"><span class="secno">2.2</span> <span class="content">Remote Playback API Requirements</span></a>
+      <li><a href="#requirements-non-functional"><span class="secno">2.3</span> <span class="content">Non-Functional Requirements</span></a>
      </ol>
-    <li><a href="#discovery"><span class="secno">4</span> <span class="content">Receiver Discovery</span></a>
-    <li><a href="#transport"><span class="secno">5</span> <span class="content">Transport Establishment</span></a>
-    <li><a href="#authentication"><span class="secno">6</span> <span class="content">Authentication</span></a>
+    <li><a href="#discovery"><span class="secno">3</span> <span class="content">Receiver Discovery</span></a>
+    <li><a href="#transport"><span class="secno">4</span> <span class="content">Transport Establishment</span></a>
+    <li><a href="#authentication"><span class="secno">5</span> <span class="content">Authentication</span></a>
     <li>
-     <a href="#control"><span class="secno">7</span> <span class="content">Control Protocols</span></a>
+     <a href="#control"><span class="secno">6</span> <span class="content">Control Protocols</span></a>
      <ol class="toc">
-      <li><a href="#presentation-api"><span class="secno">7.1</span> <span class="content">Presentation API Protocol</span></a>
-      <li><a href="#remote-playback"><span class="secno">7.2</span> <span class="content">Remote Playback API Protocol</span></a>
+      <li><a href="#presentation-api"><span class="secno">6.1</span> <span class="content">Presentation API Protocol</span></a>
+      <li><a href="#remote-playback"><span class="secno">6.2</span> <span class="content">Remote Playback API Protocol</span></a>
      </ol>
     <li>
-     <a href="#security"><span class="secno">8</span> <span class="content">Security and Privacy</span></a>
+     <a href="#security"><span class="secno">7</span> <span class="content">Security and Privacy</span></a>
      <ol class="toc">
-      <li><a href="#security-data"><span class="secno">8.1</span> <span class="content">Data to be secured</span></a>
-      <li><a href="#security-threat"><span class="secno">8.2</span> <span class="content">Threat model</span></a>
-      <li><a href="#security-defenses"><span class="secno">8.3</span> <span class="content">Mitigations and defenses</span></a>
+      <li><a href="#presentation-api-security-and-privacy"><span class="secno">7.1</span> <span class="content">Presentation API Security and Privacy</span></a>
+      <li><a href="#remote-playback-api-security-and-privacy"><span class="secno">7.2</span> <span class="content">Remote Playback API Security and Privacy</span></a>
+      <li><a href="#security-threat"><span class="secno">7.3</span> <span class="content">Threat Models</span></a>
+      <li><a href="#passive-attacks"><span class="secno">7.4</span> <span class="content">Passive Attacks</span></a>
+      <li><a href="#active-attacks"><span class="secno">7.5</span> <span class="content">Active Attacks</span></a>
+      <li><a href="#denial-of-service"><span class="secno">7.6</span> <span class="content">Denial of Service</span></a>
+      <li><a href="#security-data"><span class="secno">7.7</span> <span class="content">Data to be secured</span></a>
+      <li><a href="#security-mitigation"><span class="secno">7.8</span> <span class="content">Mitigation Strategies</span></a>
      </ol>
     <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
     <li>
@@ -1474,7 +1478,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    </ol>
   </nav>
   <main>
-   <h2 class="heading settled" data-level="1" id="status"><span class="secno">1. </span><span class="content">Status of this Document</span><a class="self-link" href="#status"></a></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
    <p>This specification was published by the <a href="https://www.w3.org/community/webscreens/">Second Screen Community
 Group</a>. It is not a W3C Standard nor
 is it on the W3C Standards Track. It should not be viewed as a stable
@@ -1485,7 +1489,7 @@ of this document will be published as a Community Group Report.</p>
 opt-out and other conditions apply.</p>
    <p>Learn more about <a href="http://www.w3.org/community/">W3C Community and Business
 Groups</a>.</p>
-   <h2 class="heading settled" data-level="2" id="introduction"><span class="secno">2. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
+   <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
    <p>The Open Screen Protocol connects browsers to devices capable of rendering Web
 content for a shared audience.  Typically, these are devices like
 Internet-connected TVs, HDMI dongles, or "smart" speakers.</p>
@@ -1502,7 +1506,7 @@ from the browser to the target display.</p>
    <p>The Open Screen Protocol is intended to be extensible, so that additional
 capabilities can be added over time.  This may include new implementations of
 existing APIs, or new APIs.</p>
-   <h3 class="heading settled" data-level="2.1" id="terminology"><span class="secno">2.1. </span><span class="content">Terminology</span><a class="self-link" href="#terminology"></a></h3>
+   <h3 class="heading settled" data-level="1.1" id="terminology"><span class="secno">1.1. </span><span class="content">Terminology</span><a class="self-link" href="#terminology"></a></h3>
    <p>We borrow terminology from the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> and <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> for terms used in this document.  These
 terms are summarized here.</p>
    <p>We call the browser that is used to discover and initiate presentation of Web
@@ -1522,8 +1526,8 @@ rendering the content of a <a data-link-type="dfn" href="https://www.w3.org/TR/h
 is called the <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-remote-playback-device" id="ref-for-dfn-remote-playback-device">remote playback device</a>.</p>
    <p>For additional terms and idioms specific to the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> or
 Remote Playback API, please consult the respective specifications.</p>
-   <h2 class="heading settled" data-level="3" id="requirements"><span class="secno">3. </span><span class="content">Requirements</span><a class="self-link" href="#requirements"></a></h2>
-   <h3 class="heading settled" data-level="3.1" id="requirements-presentation-api"><span class="secno">3.1. </span><span class="content">Presentation API Requirements</span><a class="self-link" href="#requirements-presentation-api"></a></h3>
+   <h2 class="heading settled" data-level="2" id="requirements"><span class="secno">2. </span><span class="content">Requirements</span><a class="self-link" href="#requirements"></a></h2>
+   <h3 class="heading settled" data-level="2.1" id="requirements-presentation-api"><span class="secno">2.1. </span><span class="content">Presentation API Requirements</span><a class="self-link" href="#requirements-presentation-api"></a></h3>
    <ol>
     <li data-md>
      <p>A controlling user agent must be able to discover the presence of a
@@ -1568,9 +1572,9 @@ ID</a>.</p>
      <p>The receiver must be able to signal all connected controlling user agents
 when a presentation is terminated.</p>
    </ol>
-   <h3 class="heading settled" data-level="3.2" id="requirements-remote-playback"><span class="secno">3.2. </span><span class="content">Remote Playback API Requirements</span><a class="self-link" href="#requirements-remote-playback"></a></h3>
+   <h3 class="heading settled" data-level="2.2" id="requirements-remote-playback"><span class="secno">2.2. </span><span class="content">Remote Playback API Requirements</span><a class="self-link" href="#requirements-remote-playback"></a></h3>
    <p class="issue" id="issue-a1f35a95"><a class="self-link" href="#issue-a1f35a95"></a> Requirements for Remote Playback API <a href="https://github.com/webscreens/openscreenprotocol/issues/3">&lt;https://github.com/webscreens/openscreenprotocol/issues/3></a></p>
-   <h3 class="heading settled" data-level="3.3" id="requirements-non-functional"><span class="secno">3.3. </span><span class="content">Non-Functional Requirements</span><a class="self-link" href="#requirements-non-functional"></a></h3>
+   <h3 class="heading settled" data-level="2.3" id="requirements-non-functional"><span class="secno">2.3. </span><span class="content">Non-Functional Requirements</span><a class="self-link" href="#requirements-non-functional"></a></h3>
    <ol>
     <li data-md>
      <p>It should be possible to implement an Open Screen presentation display using
@@ -1629,25 +1633,91 @@ transport levels) with optional features not defined explicitly by the
 specification, to facilitate experimentation and enhancement of the base
 APIs.</p>
    </ol>
-   <h2 class="heading settled" data-level="4" id="discovery"><span class="secno">4. </span><span class="content">Receiver Discovery</span><a class="self-link" href="#discovery"></a></h2>
+   <h2 class="heading settled" data-level="3" id="discovery"><span class="secno">3. </span><span class="content">Receiver Discovery</span><a class="self-link" href="#discovery"></a></h2>
    <p class="issue" id="issue-b7e254cb"><a class="self-link" href="#issue-b7e254cb"></a> Incorporate material from the <a href="mdns.md">mDNS</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/100">&lt;https://github.com/webscreens/openscreenprotocol/issues/100></a></p>
-   <h2 class="heading settled" data-level="5" id="transport"><span class="secno">5. </span><span class="content">Transport Establishment</span><a class="self-link" href="#transport"></a></h2>
+   <h2 class="heading settled" data-level="4" id="transport"><span class="secno">4. </span><span class="content">Transport Establishment</span><a class="self-link" href="#transport"></a></h2>
    <p class="issue" id="issue-e6fb7d40"><a class="self-link" href="#issue-e6fb7d40"></a> Incorporate material from the <a href="quic.md">QUIC</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/101">&lt;https://github.com/webscreens/openscreenprotocol/issues/101></a></p>
-   <h2 class="heading settled" data-level="6" id="authentication"><span class="secno">6. </span><span class="content">Authentication</span><a class="self-link" href="#authentication"></a></h2>
+   <h2 class="heading settled" data-level="5" id="authentication"><span class="secno">5. </span><span class="content">Authentication</span><a class="self-link" href="#authentication"></a></h2>
    <p class="issue" id="issue-7d8c18ff"><a class="self-link" href="#issue-7d8c18ff"></a> Incorporate material from the <a href="j-pake.md">J-PAKE</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/102">&lt;https://github.com/webscreens/openscreenprotocol/issues/102></a></p>
-   <h2 class="heading settled" data-level="7" id="control"><span class="secno">7. </span><span class="content">Control Protocols</span><a class="self-link" href="#control"></a></h2>
+   <h2 class="heading settled" data-level="6" id="control"><span class="secno">6. </span><span class="content">Control Protocols</span><a class="self-link" href="#control"></a></h2>
    <p class="issue" id="issue-35428ee4"><a class="self-link" href="#issue-35428ee4"></a> Describe CBOR based mechanism for
 exchanging control messages, results, and events. <a href="https://github.com/webscreens/openscreenprotocol/issues/77">&lt;https://github.com/webscreens/openscreenprotocol/issues/77></a></p>
-   <h3 class="heading settled" data-level="7.1" id="presentation-api"><span class="secno">7.1. </span><span class="content">Presentation API Protocol</span><a class="self-link" href="#presentation-api"></a></h3>
+   <h3 class="heading settled" data-level="6.1" id="presentation-api"><span class="secno">6.1. </span><span class="content">Presentation API Protocol</span><a class="self-link" href="#presentation-api"></a></h3>
    <p class="issue" id="issue-7e667595"><a class="self-link" href="#issue-7e667595"></a> Incorporate material from the <a href="protocol.md">Protocol</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/55">&lt;https://github.com/webscreens/openscreenprotocol/issues/55></a></p>
-   <h3 class="heading settled" data-level="7.2" id="remote-playback"><span class="secno">7.2. </span><span class="content">Remote Playback API Protocol</span><a class="self-link" href="#remote-playback"></a></h3>
+   <h3 class="heading settled" data-level="6.2" id="remote-playback"><span class="secno">6.2. </span><span class="content">Remote Playback API Protocol</span><a class="self-link" href="#remote-playback"></a></h3>
    <p class="issue" id="issue-eaed3698"><a class="self-link" href="#issue-eaed3698"></a> Propose control protocol for Remote
 Playback API. <a href="https://github.com/webscreens/openscreenprotocol/issues/12">&lt;https://github.com/webscreens/openscreenprotocol/issues/12></a></p>
-   <h2 class="heading settled" data-level="8" id="security"><span class="secno">8. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security"></a></h2>
-   <p class="issue" id="issue-ab35c2a2"><a class="self-link" href="#issue-ab35c2a2"></a> Describe security architecture. <a href="https://github.com/webscreens/openscreenprotocol/issues/13">&lt;https://github.com/webscreens/openscreenprotocol/issues/13></a></p>
-   <h3 class="heading settled" data-level="8.1" id="security-data"><span class="secno">8.1. </span><span class="content">Data to be secured</span><a class="self-link" href="#security-data"></a></h3>
-   <h3 class="heading settled" data-level="8.2" id="security-threat"><span class="secno">8.2. </span><span class="content">Threat model</span><a class="self-link" href="#security-threat"></a></h3>
-   <h3 class="heading settled" data-level="8.3" id="security-defenses"><span class="secno">8.3. </span><span class="content">Mitigations and defenses</span><a class="self-link" href="#security-defenses"></a></h3>
+   <h2 class="heading settled" data-level="7" id="security"><span class="secno">7. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security"></a></h2>
+   <p>The Open Screen Protocol should, at a minimum, conform to the security and
+privacy guidelines recommended by the [[PRESENTATION-API][Presentation API]] and
+the [[REMOTE-PLAYBACK][Remote Playback API]].</p>
+   <p>In addition, the Open Screen Protocol itself has additional security and privacy
+considerations.</p>
+   <h3 class="heading settled" data-level="7.1" id="presentation-api-security-and-privacy"><span class="secno">7.1. </span><span class="content">Presentation API Security and Privacy</span><a class="self-link" href="#presentation-api-security-and-privacy"></a></h3>
+   <p>The [[PRESENTATION-API#security-and-privacy-considerations][Presentation API
+Security and Privacy Considerations]] place these requirements on the Open
+Screen Protocol:</p>
+   <ol>
+    <li data-md>
+     <p>Presentation URLs and presentation IDs should remain private among the
+parties that are allowed to connect to a presentation, per the
+cross-origin access guidelines.</p>
+    <li data-md>
+     <p>Controllers and recievers should be notified when multiple connections have
+been made to a presentation, per the user interface guidelines.</p>
+    <li data-md>
+     <p>Messaging between presentations and controllers should be authenticated and
+confidential, per the guidelines for messaging between presentation
+connections.</p>
+   </ol>
+   <h3 class="heading settled" data-level="7.2" id="remote-playback-api-security-and-privacy"><span class="secno">7.2. </span><span class="content">Remote Playback API Security and Privacy</span><a class="self-link" href="#remote-playback-api-security-and-privacy"></a></h3>
+   <p>The [[REMOTE-PLAYBACK#security-and-privacy-considerations][Remote Playback API
+Security and Privacy Considerations]] also state that messaging between local
+and remote playback devices should also be authenticated and confidential.</p>
+   <h3 class="heading settled" data-level="7.3" id="security-threat"><span class="secno">7.3. </span><span class="content">Threat Models</span><a class="self-link" href="#security-threat"></a></h3>
+   <h3 class="heading settled" data-level="7.4" id="passive-attacks"><span class="secno">7.4. </span><span class="content">Passive Attacks</span><a class="self-link" href="#passive-attacks"></a></h3>
+   <p>The Open Screen Protocol should assume that all parties that are able
+access the LAN, either through a wired connection or through WiFi, are able to
+observe all data flowing between Open Screen controllers and receivers.</p>
+   <p>These parties will be able collect any data exposed through unencrypted
+messages, such as mDNS records and the QUIC handshake.</p>
+   <h3 class="heading settled" data-level="7.5" id="active-attacks"><span class="secno">7.5. </span><span class="content">Active Attacks</span><a class="self-link" href="#active-attacks"></a></h3>
+   <p>In addition, all parties with access to the LAN will be able to manipulate data
+exchanged between controllers and receivers and inititate QUIC connections.
+This can be used to attempt attacks such as:</p>
+   <ul>
+    <li data-md>
+     <p>Impersonating a new receiver or one already known to the user, in an attempt
+to convince the user to authenticate it as a trusted receiver.</p>
+    <li data-md>
+     <p>Connecting to a receiver and querying its capabilities, or attempting to
+connect to a running presentation or remote playback.</p>
+   </ul>
+   <h3 class="heading settled" data-level="7.6" id="denial-of-service"><span class="secno">7.6. </span><span class="content">Denial of Service</span><a class="self-link" href="#denial-of-service"></a></h3>
+   <h3 class="heading settled" data-level="7.7" id="security-data"><span class="secno">7.7. </span><span class="content">Data to be secured</span><a class="self-link" href="#security-data"></a></h3>
+   <p>There are two kinds of data</p>
+   <ol>
+    <li data-md>
+     <p>Presentation URLs</p>
+    <li data-md>
+     <p>Presentation IDs</p>
+    <li data-md>
+     <p>Presentation connection messages</p>
+    <li data-md>
+     <p>Remote playback URLs</p>
+    <li data-md>
+     <p>Remote playback commands and status messages</p>
+   </ol>
+   <p>The following data cannot be reasonably secured and should be considered public
+and untrusted data:</p>
+   <ol>
+    <li data-md>
+     <p>IP addresses and ports used by the Open Screen Protocol.</p>
+    <li data-md>
+     <p>Friendly names or other data advertised through mDNS.</p>
+    <li data-md>
+   </ol>
+   <h3 class="heading settled" data-level="7.8" id="security-mitigation"><span class="secno">7.8. </span><span class="content">Mitigation Strategies</span><a class="self-link" href="#security-mitigation"></a></h3>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -1799,75 +1869,75 @@ Playback API. <a href="https://github.com/webscreens/openscreenprotocol/issues/1
   <aside class="dfn-panel" data-for="term-for-media-element">
    <a href="https://www.w3.org/TR/html51/single-page.html#media-element">https://www.w3.org/TR/html51/single-page.html#media-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-media-element">2.1. Terminology</a>
+    <li><a href="#ref-for-media-element">1.1. Terminology</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-presentationconnection">
    <a href="https://w3c.github.io/presentation-api/#presentationconnection">https://w3c.github.io/presentation-api/#presentationconnection</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-presentationconnection">3.1. Presentation API Requirements</a> <a href="#ref-for-presentationconnection①">(2)</a>
+    <li><a href="#ref-for-presentationconnection">2.1. Presentation API Requirements</a> <a href="#ref-for-presentationconnection①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-controlling-browsing-context">
    <a href="https://w3c.github.io/presentation-api/#dfn-controlling-browsing-context">https://w3c.github.io/presentation-api/#dfn-controlling-browsing-context</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-controlling-browsing-context">2.1. Terminology</a>
+    <li><a href="#ref-for-dfn-controlling-browsing-context">1.1. Terminology</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-controlling-user-agent">
    <a href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent">https://w3c.github.io/presentation-api/#dfn-controlling-user-agent</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-controlling-user-agent">2.1. Terminology</a> <a href="#ref-for-dfn-controlling-user-agent①">(2)</a>
-    <li><a href="#ref-for-dfn-controlling-user-agent②">3.1. Presentation API Requirements</a>
+    <li><a href="#ref-for-dfn-controlling-user-agent">1.1. Terminology</a> <a href="#ref-for-dfn-controlling-user-agent①">(2)</a>
+    <li><a href="#ref-for-dfn-controlling-user-agent②">2.1. Presentation API Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-presentation-display">
    <a href="https://w3c.github.io/presentation-api/#dfn-presentation-display">https://w3c.github.io/presentation-api/#dfn-presentation-display</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-presentation-display">2.1. Terminology</a>
+    <li><a href="#ref-for-dfn-presentation-display">1.1. Terminology</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-presentation-display-availability">
    <a href="https://w3c.github.io/presentation-api/#dfn-presentation-display-availability">https://w3c.github.io/presentation-api/#dfn-presentation-display-availability</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-presentation-display-availability">2.1. Terminology</a>
+    <li><a href="#ref-for-dfn-presentation-display-availability">1.1. Terminology</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-presentation-id">
    <a href="https://w3c.github.io/presentation-api/#dfn-presentation-id">https://w3c.github.io/presentation-api/#dfn-presentation-id</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-presentation-id">3.1. Presentation API Requirements</a> <a href="#ref-for-dfn-presentation-id①">(2)</a> <a href="#ref-for-dfn-presentation-id②">(3)</a>
+    <li><a href="#ref-for-dfn-presentation-id">2.1. Presentation API Requirements</a> <a href="#ref-for-dfn-presentation-id①">(2)</a> <a href="#ref-for-dfn-presentation-id②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-presentation-request-url">
    <a href="https://w3c.github.io/presentation-api/#dfn-presentation-request-url">https://w3c.github.io/presentation-api/#dfn-presentation-request-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-presentation-request-url">2.1. Terminology</a> <a href="#ref-for-dfn-presentation-request-url①">(2)</a>
-    <li><a href="#ref-for-dfn-presentation-request-url②">3.1. Presentation API Requirements</a> <a href="#ref-for-dfn-presentation-request-url③">(2)</a> <a href="#ref-for-dfn-presentation-request-url④">(3)</a> <a href="#ref-for-dfn-presentation-request-url⑤">(4)</a>
+    <li><a href="#ref-for-dfn-presentation-request-url">1.1. Terminology</a> <a href="#ref-for-dfn-presentation-request-url①">(2)</a>
+    <li><a href="#ref-for-dfn-presentation-request-url②">2.1. Presentation API Requirements</a> <a href="#ref-for-dfn-presentation-request-url③">(2)</a> <a href="#ref-for-dfn-presentation-request-url④">(3)</a> <a href="#ref-for-dfn-presentation-request-url⑤">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-receiver">
    <a href="https://w3c.github.io/presentation-api/#dfn-receiver">https://w3c.github.io/presentation-api/#dfn-receiver</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-receiver">2.1. Terminology</a>
+    <li><a href="#ref-for-dfn-receiver">1.1. Terminology</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-receiving-browsing-context">
    <a href="https://w3c.github.io/presentation-api/#dfn-receiving-browsing-context">https://w3c.github.io/presentation-api/#dfn-receiving-browsing-context</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-receiving-browsing-context">2.1. Terminology</a>
+    <li><a href="#ref-for-dfn-receiving-browsing-context">1.1. Terminology</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-receiving-user-agent">
    <a href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent">https://w3c.github.io/presentation-api/#dfn-receiving-user-agent</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-receiving-user-agent">2.1. Terminology</a>
+    <li><a href="#ref-for-dfn-receiving-user-agent">1.1. Terminology</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-remote-playback-device">
    <a href="https://w3c.github.io/remote-playback/#dfn-remote-playback-device">https://w3c.github.io/remote-playback/#dfn-remote-playback-device</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-remote-playback-device">2.1. Terminology</a>
+    <li><a href="#ref-for-dfn-remote-playback-device">1.1. Terminology</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -1920,7 +1990,6 @@ exchanging control messages, results, and events. <a href="https://github.com/we
    <div class="issue"> Incorporate material from the <a href="protocol.md">Protocol</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/55">&lt;https://github.com/webscreens/openscreenprotocol/issues/55></a><a href="#issue-7e667595"> ↵ </a></div>
    <div class="issue"> Propose control protocol for Remote
 Playback API. <a href="https://github.com/webscreens/openscreenprotocol/issues/12">&lt;https://github.com/webscreens/openscreenprotocol/issues/12></a><a href="#issue-eaed3698"> ↵ </a></div>
-   <div class="issue"> Describe security architecture. <a href="https://github.com/webscreens/openscreenprotocol/issues/13">&lt;https://github.com/webscreens/openscreenprotocol/issues/13></a><a href="#issue-ab35c2a2"> ↵ </a></div>
   </div>
 <script>/* script-dfn-panel */
 

--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 0da7328bb90ef81993146377e4e0fed236969c4c" name="generator">
+  <meta content="Bikeshed version 9c6ae748322940994300e90a77c34437364b40a6" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="12c20f3f4457b2abd8af472eb171ca579198e1d0" name="document-revision">
+  <meta content="3e0675f2a5988fafb4a697958a7314c695dfdb42" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1403,11 +1403,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-<<<<<<< HEAD
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-03-05">5 March 2019</time></span></h2>
-=======
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-03-22">22 March 2019</time></span></h2>
->>>>>>> Address more comments
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-03-25">25 March 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2261,26 +2257,32 @@ Protocol prevents a man-in-the-middle from impersonating an agent, without
 knowledge of a shared secret.  However, it is possible for an attacker to
 impersonate an existing, trusted display or a newly discovered display that is
 not yet authenticated and try to convince the user to authenticate it.</p>
-   <p>This can be addressed through a combination of techniques.  The first is flagging:</p>
+   <p>This can be addressed through a combination of techniques.  The first is
+detecting and flagging attempts at impersonation; a few of the situations that
+should be flagged include:</p>
    <ul>
     <li data-md>
-     <p>Flag an advertised display whose public key fingerprint collides with that
-from an already-trusted display that is concurrently being advertised.</p>
+     <p>Untrusted agents whose public key fingerprint collides with that from an
+already-trusted agent that is concurrently being advertised.</p>
     <li data-md>
-     <p>Flag an advertised display whose friendly name differs from the one previously
-advertised under a public key fingerprint.</p>
+     <p>Untrusted agents whose friendly name differs from the one previously
+advertised under a given public key fingerprint.</p>
     <li data-md>
-     <p>Flag already-trusted displays whose metadata has changed.</p>
+     <p>Untrusted agents that fail the authentication challenge a certain number of times.</p>
     <li data-md>
-     <p>Flag agents that fail the authentication challenge a certain number of times.</p>
+     <p>Untrusted agents that advertise a friendly name that is similar to that from an
+already-trusted agent.</p>
+    <li data-md>
+     <p>Already-trusted agents whose metadata provided through the <code>agent-info</code> message has changed.</p>
    </ul>
-   <p>Flagging means that the user is notified, or in some cases they are required to
-re-authenticate to the presentation display to verify its identity.</p>
-   <p>The second is through management of the shared secret during mutual
+   <p>Flagging means that the user is notified of the attempt at impersonation.  In
+the last case, the user should be required to re-authenticate to the
+already-trusted agent to verify its identity.</p>
+   <p>The second is through management of the low-entropy secret during mutual
 authentication:</p>
    <ul>
     <li data-md>
-     <p>Rotate the shared secret to prevent brute force attacks.</p>
+     <p>Rotate the low-entropy secret to prevent brute force attacks.</p>
     <li data-md>
      <p>Use an increasing backoff to respond to authentication challenges, also to
 prevent brute force attacks.</p>
@@ -2296,18 +2298,16 @@ by a correct implementation of TLS 1.3.</p>
    <p class="issue" id="issue-5107ff88①"><a class="self-link" href="#issue-5107ff88①"></a> [Security] Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a></p>
    <h4 class="heading settled" data-level="8.5.3" id="remote-active-mitigations"><span class="secno">8.5.3. </span><span class="content">Remote active network attackers</span><a class="self-link" href="#remote-active-mitigations"></a></h4>
    <p>Unfortunately, we cannot rely on network devices to fully protect Open Screen
-Protocol agents from traffic from the broader Internet.  Open Screen Protocol
-agents that are only intended to work on the LAN should filter packets
-from non-local IP addresses.  Agents can also use the ARP cache to
-detect attempts to spoof local network IP addresses.</p>
+Protocol agents, because a misconfigured firewall or NAT could expose a
+LAN-connected agent to the broader Internet.  Open Screen Protocol agents
+should be secure against attack from any Inernet host.</p>
    <p class="issue" id="issue-1353180f"><a class="self-link" href="#issue-1353180f"></a> [Security] Mitigations for remote network attackers <a href="https://github.com/webscreens/openscreenprotocol/issues/131">&lt;https://github.com/webscreens/openscreenprotocol/issues/131></a></p>
    <h4 class="heading settled" data-level="8.5.4" id="denial-of-service-mitigations"><span class="secno">8.5.4. </span><span class="content">Denial of service</span><a class="self-link" href="#denial-of-service-mitigations"></a></h4>
    <p>It will be difficult to completely prevent denial service of attacks that
 originate on the user’s local area network.  Open Screen Protocol agents can
-refuse new connections, rate limit the rate of messages from existing
-connections, or limit the number of mDNS records cached from a specific
-responder in an attempt to allow existing activities to continue in spite of
-such an attack.</p>
+refuse new connections, close connections that receive too many messages, or
+limit the number of mDNS records cached from a specific responder in an attempt
+to allow existing activities to continue in spite of such an attack.</p>
    <h4 class="heading settled" data-level="8.5.5" id="malicious-input-mitigations"><span class="secno">8.5.5. </span><span class="content">Malicious input</span><a class="self-link" href="#malicious-input-mitigations"></a></h4>
    <p>Open Screen Protocol agents should be robust against malicious input that
 attempts to compromise the target device by exploiting parsing vulnerabilities.</p>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version a816d78e14132d4d4d2ee44ccaf1b8bc90ac75d5" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="675ca5260156b7e1fd42b55a771f1ff655f048bc" name="document-revision">
+  <meta content="fbfe37e986003f26623c89abb786488b2e73f8ae" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1454,17 +1454,38 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li><a href="#remote-playback"><span class="secno">7.3</span> <span class="content">Remote Playback API Protocol</span></a>
      </ol>
     <li>
-     <a href="#security"><span class="secno">8</span> <span class="content">Security and Privacy</span></a>
+     <a href="#security-privacy"><span class="secno">8</span> <span class="content">Security and Privacy</span></a>
      <ol class="toc">
-      <li><a href="#presentation-api①"><span class="secno">8.1</span> <span class="content">Presentation API</span></a>
-      <li><a href="#remote-playback-api"><span class="secno">8.2</span> <span class="content">Remote Playback API</span></a>
-      <li><a href="#open-screen-protocol"><span class="secno">8.3</span> <span class="content">Open Screen Protocol</span></a>
-      <li><a href="#security-threat"><span class="secno">8.4</span> <span class="content">Threat Models</span></a>
-      <li><a href="#passive-attacks"><span class="secno">8.5</span> <span class="content">Passive Attacks</span></a>
-      <li><a href="#active-attacks"><span class="secno">8.6</span> <span class="content">Active Attacks</span></a>
-      <li><a href="#denial-of-service"><span class="secno">8.7</span> <span class="content">Denial of Service</span></a>
-      <li><a href="#security-data"><span class="secno">8.8</span> <span class="content">Data to be secured</span></a>
-      <li><a href="#security-mitigation"><span class="secno">8.9</span> <span class="content">Mitigation Strategies</span></a>
+      <li>
+       <a href="#threat-models"><span class="secno">8.1</span> <span class="content">Threat Models</span></a>
+       <ol class="toc">
+        <li><a href="#passive-network-attackers"><span class="secno">8.1.1</span> <span class="content">Passive Network Attackers</span></a>
+        <li><a href="#active-network-attackers"><span class="secno">8.1.2</span> <span class="content">Active Network Attackers</span></a>
+        <li><a href="#denial-of-service"><span class="secno">8.1.3</span> <span class="content">Denial of Service</span></a>
+        <li><a href="#same-origin-policy-violations"><span class="secno">8.1.4</span> <span class="content">Same-Origin Policy Violations</span></a>
+        <li><a href="#third-party-tracking"><span class="secno">8.1.5</span> <span class="content">Third Party Tracking</span></a>
+       </ol>
+      <li>
+       <a href="#security-privacy-questions"><span class="secno">8.2</span> <span class="content">Open Screen Protocol Considerations</span></a>
+       <ol class="toc">
+        <li><a href="#personally-identifiable-information"><span class="secno">8.2.1</span> <span class="content">Personally Identifiable Information &amp; High-Value Data</span></a>
+        <li><a href="#cross-origin-state"><span class="secno">8.2.2</span> <span class="content">Cross Origin State Considerations</span></a>
+        <li><a href="#origin-access-devices"><span class="secno">8.2.3</span> <span class="content">Origin Access to Other Devices</span></a>
+        <li><a href="#incognito-mode"><span class="secno">8.2.4</span> <span class="content">Incognito Mode</span></a>
+        <li><a href="#persistent-state"><span class="secno">8.2.5</span> <span class="content">Persistent State</span></a>
+        <li><a href="#other-considerations"><span class="secno">8.2.6</span> <span class="content">Other Considerations</span></a>
+       </ol>
+      <li><a href="#presentation-api-considerations"><span class="secno">8.3</span> <span class="content">Presentation API Considerations</span></a>
+      <li><a href="#remote-playback-considerations"><span class="secno">8.4</span> <span class="content">Remote Playback API Considerations</span></a>
+      <li>
+       <a href="#security-mitigations"><span class="secno">8.5</span> <span class="content">Mitigation Strategies</span></a>
+       <ol class="toc">
+        <li><a href="#local-passive-mitigations"><span class="secno">8.5.1</span> <span class="content">Local passive network attackers</span></a>
+        <li><a href="#local-active-mitigations"><span class="secno">8.5.2</span> <span class="content">Local active network attackers</span></a>
+        <li><a href="#remote-active-mitigations"><span class="secno">8.5.3</span> <span class="content">Remote active network attackers</span></a>
+        <li><a href="#denial-of-service-mitigations"><span class="secno">8.5.4</span> <span class="content">Denial of service</span></a>
+        <li><a href="#malicious-input-mitigations"><span class="secno">8.5.5</span> <span class="content">Malicious input</span></a>
+       </ol>
      </ol>
     <li><a href="#appendix-a"><span class="secno"></span> <span class="content">Appendix A: Messages</span></a>
     <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
@@ -1960,13 +1981,134 @@ agent</a>, must send a presentation-connection-open-response message.</p>
    <h3 class="heading settled" data-level="7.3" id="remote-playback"><span class="secno">7.3. </span><span class="content">Remote Playback API Protocol</span><a class="self-link" href="#remote-playback"></a></h3>
    <p class="issue" id="issue-eaed3698"><a class="self-link" href="#issue-eaed3698"></a> Propose control protocol for Remote
 Playback API. <a href="https://github.com/webscreens/openscreenprotocol/issues/12">&lt;https://github.com/webscreens/openscreenprotocol/issues/12></a></p>
-   <h2 class="heading settled" data-level="8" id="security"><span class="secno">8. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security"></a></h2>
-   <p>The Open Screen Protocol should, at a minimum, conform to the security and
-privacy guidelines recommended by the [[PRESENTATION-API][Presentation API]] and
-the [[REMOTE-PLAYBACK][Remote Playback API]].</p>
-   <p>In addition, the Open Screen Protocol itself adds additional security and privacy
-considerations.</p>
-   <h3 class="heading settled" data-level="8.1" id="presentation-api①"><span class="secno">8.1. </span><span class="content">Presentation API</span><a class="self-link" href="#presentation-api①"></a></h3>
+   <h2 class="heading settled" data-level="8" id="security-privacy"><span class="secno">8. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security-privacy"></a></h2>
+   <p>The Open Screen Protocol allows two networked user agents to discover each other
+and exchange user and application data.  As such, its security and privacy
+considerations should be closely examined.  We first evaluate the protocol
+itself using the W3C <a data-link-type="biblio" href="#biblio-security-privacy-questionnaire">[SECURITY-PRIVACY-QUESTIONNAIRE]</a>.  We then examine
+whether the security and privacy guidelines recommended by the <a data-link-type="biblio" href="#biblio-presentation-api">[PRESENTATION-API]</a> and the [[REMOTE-PLAYBACK] are met.</p>
+   <h3 class="heading settled" data-level="8.1" id="threat-models"><span class="secno">8.1. </span><span class="content">Threat Models</span><a class="self-link" href="#threat-models"></a></h3>
+   <h4 class="heading settled" data-level="8.1.1" id="passive-network-attackers"><span class="secno">8.1.1. </span><span class="content">Passive Network Attackers</span><a class="self-link" href="#passive-network-attackers"></a></h4>
+   <p>The Open Screen Protocol should assume that all parties that are connected to
+the same LAN as the user agents, either through a wired connection or through
+WiFi, are able to observe all data flowing between Open Screen controllers and
+receivers.</p>
+   <p>These parties will be able collect any data exposed through unencrypted
+messages, such as mDNS records and the QUIC handshake.</p>
+   <p>These parties may attempt to learn cryptographic parameters by observing data
+flows on the QUIC connection, or by observing cryptographic timing.</p>
+   <h4 class="heading settled" data-level="8.1.2" id="active-network-attackers"><span class="secno">8.1.2. </span><span class="content">Active Network Attackers</span><a class="self-link" href="#active-network-attackers"></a></h4>
+   <p>In addition, all parties with access to the LAN will be able to manipulate data
+exchanged between controllers and receivers.  They will be able to inject
+traffic into both parties and attempt to inititate new QUIC connections.  These abilities
+can be used to attempt the following:</p>
+   <ul>
+    <li data-md>
+     <p>Impersonate a new receiver or one already trusted by the user, in an attempt
+to convince the user to authenticate to it.</p>
+    <li data-md>
+     <p>Connect to a receiver and query its capabilities.</p>
+    <li data-md>
+     <p>Connect to and control a presentation or remote playback, or extract data
+from the application state of the presentation or remote playback.</p>
+   </ul>
+   <p>One particular attack of concern is misconfigured or compromised routers that
+expose local network devices to the Internet.  This vector of attack has been
+used by remote parties to take control of printers and smart TVs by connecting
+to local network services that should normally be inaccessible from the
+Internet.</p>
+   <h4 class="heading settled" data-level="8.1.3" id="denial-of-service"><span class="secno">8.1.3. </span><span class="content">Denial of Service</span><a class="self-link" href="#denial-of-service"></a></h4>
+   <p>Parties with access to the LAN may attempt to deny access to receivers by
+controllers, or vice versa.  For example, an active attacker my attempt to start
+a large number of QUIC connections on a receiver in an attempt to block
+legitimate connections or exhaust available resources on the presentation
+display.  They may also multicast spurious DNS-SD records in an attempt to
+exhaust the cache capacity for mDNS listeners.</p>
+   <h4 class="heading settled" data-level="8.1.4" id="same-origin-policy-violations"><span class="secno">8.1.4. </span><span class="content">Same-Origin Policy Violations</span><a class="self-link" href="#same-origin-policy-violations"></a></h4>
+   <p>The Presentation API allows cross-origin communication between controlling pages
+and presentations with the consent of each origin (through their use of the
+API).  This is similar to cross-origin communication via <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage" id="ref-for-dom-worker-postmessage">postMessage</a></code>.  The
+Open Screen Protocol does not convey origin information between controllers and
+receivers.</p>
+   <p>The <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-id" id="ref-for-dfn-presentation-id③">presentation ID</a> carries some protection against unrestricted
+cross-origin access, but authentication of the parties connected by a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection②">PresentationConnection</a></code> can be done at the application level.</p>
+   <h4 class="heading settled" data-level="8.1.5" id="third-party-tracking"><span class="secno">8.1.5. </span><span class="content">Third Party Tracking</span><a class="self-link" href="#third-party-tracking"></a></h4>
+   <p>The Open Screen Protocol does not give third party origins additional access to
+presentations or remote playback state.</p>
+   <h3 class="heading settled" data-level="8.2" id="security-privacy-questions"><span class="secno">8.2. </span><span class="content">Open Screen Protocol Considerations</span><a class="self-link" href="#security-privacy-questions"></a></h3>
+   <h4 class="heading settled" data-level="8.2.1" id="personally-identifiable-information"><span class="secno">8.2.1. </span><span class="content">Personally Identifiable Information &amp; High-Value Data</span><a class="self-link" href="#personally-identifiable-information"></a></h4>
+   <p>The following data exchanged by the protocol can be personally identifiable and
+thus is high value data:</p>
+   <ol>
+    <li data-md>
+     <p>Presentation URLs and availability results</p>
+    <li data-md>
+     <p>Presentation IDs</p>
+    <li data-md>
+     <p>Presentation connection IDs</p>
+    <li data-md>
+     <p>Presentation connection messages</p>
+    <li data-md>
+     <p>Remote playback URLs</p>
+    <li data-md>
+     <p>Remote playback commands and status messages</p>
+   </ol>
+   <p>Presentation display friendly names, model names, and capabilities, while not
+considered personally identifiable, is important to protect to preserve the
+integrity of the discovery process.</p>
+   <p>The following data cannot be reasonably secured and should be considered public
+and untrusted data:</p>
+   <ol>
+    <li data-md>
+     <p>IP addresses and ports used by the Open Screen Protocol.</p>
+    <li data-md>
+     <p>Data advertised through mDNS, including the certificate fingerprint and the
+metadata version.</p>
+   </ol>
+   <h4 class="heading settled" data-level="8.2.2" id="cross-origin-state"><span class="secno">8.2.2. </span><span class="content">Cross Origin State Considerations</span><a class="self-link" href="#cross-origin-state"></a></h4>
+   <p>Access to origin state across browsing sessions is possible through the
+Presentation API by reconnecting to a presentation that was started by a
+previous session. This sceanrio is addressed in <a href="https://www.w3.org/TR/presentation-api/#cross-origin-access">Presentation API §cross-origin-access</a>.</p>
+   <p>Presentation display availability and remote playback availability are states
+that may be available cross-origin depending on the user’s network context.
+Exposure of this data to the Web is also discussed in <a href="https://www.w3.org/TR/presentation-api/#personally-identifiable-information">Presentation API §personally-identifiable-information</a> and <a href="https://www.w3.org/TR/remote-playback/#personally-identifiable-information">Remote Playback API §personally-identifiable-information</a>.</p>
+   <h4 class="heading settled" data-level="8.2.3" id="origin-access-devices"><span class="secno">8.2.3. </span><span class="content">Origin Access to Other Devices</span><a class="self-link" href="#origin-access-devices"></a></h4>
+   <p>By design, the Open Screen Protocol allows access to presentation displays from
+the Web.  By implementing the protocol, these devices are knowingly making
+themselves available to the Web and should be designed accordingly.</p>
+   <p>Below, we discuss mitigation steps to prevent malicious use of presentation
+displays.</p>
+   <h4 class="heading settled" data-level="8.2.4" id="incognito-mode"><span class="secno">8.2.4. </span><span class="content">Incognito Mode</span><a class="self-link" href="#incognito-mode"></a></h4>
+   <p>The Open Screen Protocol does not distinguish between the user agent’s normal
+browsing and incognito modes, and should operate identically regardless of which
+mode is using it.</p>
+   <h4 class="heading settled" data-level="8.2.5" id="persistent-state"><span class="secno">8.2.5. </span><span class="content">Persistent State</span><a class="self-link" href="#persistent-state"></a></h4>
+   <p>An implementation of the Open Screen Protocol is likely to persist the identity
+of controllers and receivers that have successfully completed <a href="#authentication">§6 Authentication</a>.  This may include the public key fingerprints, metadata
+versions, and metadata for those parties.</p>
+   <p>However, this data is not normally exposed to the Web, only through the native
+UI of the user agent during the display selection or display authentication
+process.  It can be an implementation choice whether the user agent clears or
+retains this data when the user clears browsing data.</p>
+   <p>TODO: File an issue to discuss</p>
+   <h4 class="heading settled" data-level="8.2.6" id="other-considerations"><span class="secno">8.2.6. </span><span class="content">Other Considerations</span><a class="self-link" href="#other-considerations"></a></h4>
+   <p>The Open Screen Protocol does not grant to the Web additional access to the
+following:</p>
+   <ul>
+    <li data-md>
+     <p>New script loading mechanisms</p>
+    <li data-md>
+     <p>Access to the user’s location</p>
+    <li data-md>
+     <p>Access to device sensors</p>
+    <li data-md>
+     <p>Access to the user’s local computing environment</p>
+    <li data-md>
+     <p>Control over the user agent’s native UI</p>
+    <li data-md>
+     <p>Security characteristics of the user agent</p>
+   </ul>
+   <h3 class="heading settled" data-level="8.3" id="presentation-api-considerations"><span class="secno">8.3. </span><span class="content">Presentation API Considerations</span><a class="self-link" href="#presentation-api-considerations"></a></h3>
    <p>[[PRESENTATION-API#security-and-privacy-considerations][Presentation API
 Security and Privacy Considerations]] place these requirements on the Open
 Screen Protocol:</p>
@@ -1983,55 +2125,93 @@ been made to a presentation, per the user interface guidelines.</p>
 confidential, per the guidelines for messaging between presentation
 connections.</p>
    </ol>
-   <h3 class="heading settled" data-level="8.2" id="remote-playback-api"><span class="secno">8.2. </span><span class="content">Remote Playback API</span><a class="self-link" href="#remote-playback-api"></a></h3>
+   <p>The Open Screen Protocol addresses these considerations by:</p>
+   <ol>
+    <li data-md>
+     <p>Requiring mutual authentication and a TLS-secured QUIC connection before
+ presentation URLs, IDs, or messages are exchanged.</p>
+    <li data-md>
+     <p>Adding explicit messages and connection IDs for individual <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection③">PresentationConnections</a></code> so that controllers and
+ receivers can track the number of active connections.</p>
+   </ol>
+   <h3 class="heading settled" data-level="8.4" id="remote-playback-considerations"><span class="secno">8.4. </span><span class="content">Remote Playback API Considerations</span><a class="self-link" href="#remote-playback-considerations"></a></h3>
    <p>The [[REMOTE-PLAYBACK#security-and-privacy-considerations][Remote Playback API
 Security and Privacy Considerations]] also state that messaging between local
 and remote playback devices should also be authenticated and confidential.</p>
-   <h3 class="heading settled" data-level="8.3" id="open-screen-protocol"><span class="secno">8.3. </span><span class="content">Open Screen Protocol</span><a class="self-link" href="#open-screen-protocol"></a></h3>
-   <h3 class="heading settled" data-level="8.4" id="security-threat"><span class="secno">8.4. </span><span class="content">Threat Models</span><a class="self-link" href="#security-threat"></a></h3>
-   <h3 class="heading settled" data-level="8.5" id="passive-attacks"><span class="secno">8.5. </span><span class="content">Passive Attacks</span><a class="self-link" href="#passive-attacks"></a></h3>
-   <p>The Open Screen Protocol should assume that all parties that are able
-access the LAN, either through a wired connection or through WiFi, are able to
-observe all data flowing between Open Screen controllers and receivers.</p>
-   <p>These parties will be able collect any data exposed through unencrypted
-messages, such as mDNS records and the QUIC handshake.</p>
-   <h3 class="heading settled" data-level="8.6" id="active-attacks"><span class="secno">8.6. </span><span class="content">Active Attacks</span><a class="self-link" href="#active-attacks"></a></h3>
-   <p>In addition, all parties with access to the LAN will be able to manipulate data
-exchanged between controllers and receivers and inititate QUIC connections.
-This can be used to attempt attacks such as:</p>
+   <p>This consideration is handled by requiring mutual authentication and a
+TLS-secured QUIC connection before any remote playback related messages are
+exchanged.</p>
+   <h3 class="heading settled" data-level="8.5" id="security-mitigations"><span class="secno">8.5. </span><span class="content">Mitigation Strategies</span><a class="self-link" href="#security-mitigations"></a></h3>
+   <h4 class="heading settled" data-level="8.5.1" id="local-passive-mitigations"><span class="secno">8.5.1. </span><span class="content">Local passive network attackers</span><a class="self-link" href="#local-passive-mitigations"></a></h4>
+   <p>Local passive attackers may attempt to harvest data about user activities and
+device capabilties using the Open Screen Protocol.  The main strategy to address
+this is data minimization, by only exposing opaque public key fingerprints
+before user-mediated authentication takes place.</p>
+   <p>Passive attackers may also attempt timing attacks to learn cryptographic the
+cryptographic parameters of the TLS 1.3 QUIC connection.</p>
+   <p>TODO: Investigate mitigations for this.</p>
+   <h4 class="heading settled" data-level="8.5.2" id="local-active-mitigations"><span class="secno">8.5.2. </span><span class="content">Local active network attackers</span><a class="self-link" href="#local-active-mitigations"></a></h4>
+   <p>Local active attackers may attempt to impersonate a presentation display the
+user would normally trust.  The <a href="#authentication">§6 Authentication</a> step of the Open Screen
+Protocol prevents a man-in-the-middle from impersonating a controller or
+receiver, without knowledge of a shared secret.  However, it is possible for an
+attacker to impersonate an existing, trusted display or a newly discovered
+display that is not yet authenticated by convincing the user to authenticate it.</p>
+   <p>This can be addressed through a combination of techniques.  The first is flagging:</p>
    <ul>
     <li data-md>
-     <p>Impersonating a new receiver or one already known to the user, in an attempt
-to convince the user to authenticate it as a trusted receiver.</p>
+     <p>Flag advertised displays whose friendly name, public key fingerprint, or
+IP:port collide with an already trusted display.</p>
     <li data-md>
-     <p>Connecting to a receiver and querying its capabilities, or attempting to
-xconnect to a running presentation or remote playback.</p>
+     <p>Flag already-trusted displays whose metadata has changed.</p>
+    <li data-md>
+     <p>Flag controllers or receivers that fail the authentication challenge a certain
+number of times.</p>
    </ul>
-   <h3 class="heading settled" data-level="8.7" id="denial-of-service"><span class="secno">8.7. </span><span class="content">Denial of Service</span><a class="self-link" href="#denial-of-service"></a></h3>
-   <h3 class="heading settled" data-level="8.8" id="security-data"><span class="secno">8.8. </span><span class="content">Data to be secured</span><a class="self-link" href="#security-data"></a></h3>
-   <p>There are two kinds of data</p>
-   <ol>
+   <p>Flagging means that the user is notified, or in some cases they are required to
+re-authenticate to the presentation display to verify its identity.</p>
+   <p>The second is through management of the shared secret during mutual
+authentication:</p>
+   <ul>
     <li data-md>
-     <p>Presentation URLs</p>
+     <p>Rotate the shared secret to prevent brute force attacks.</p>
     <li data-md>
-     <p>Presentation IDs</p>
+     <p>Use an increasing backoff to repond to authentication challenges, also to
+prevent brute force attacks.</p>
     <li data-md>
-     <p>Presentation connection messages</p>
+     <p>Use a cryptographically sound source of entropy to generate the shared secret.</p>
     <li data-md>
-     <p>Remote playback URLs</p>
-    <li data-md>
-     <p>Remote playback commands and status messages</p>
-   </ol>
-   <p>The following data cannot be reasonably secured and should be considered public
-and untrusted data:</p>
-   <ol>
-    <li data-md>
-     <p>IP addresses and ports used by the Open Screen Protocol.</p>
-    <li data-md>
-     <p>Friendly names or other data advertised through mDNS.</p>
-    <li data-md>
-   </ol>
-   <h3 class="heading settled" data-level="8.9" id="security-mitigation"><span class="secno">8.9. </span><span class="content">Mitigation Strategies</span><a class="self-link" href="#security-mitigation"></a></h3>
+     <p>Require the end user to manually type the shared secret - shown only the
+display - to prevent the user from blindly clicking through this step.</p>
+   </ul>
+   <p>The active attacker may also attempt to disrupt data exchanged over the QUIC
+connection by injecting or modifying traffic.  These attacks should be mitigated
+by a correct implementation of TLS 1.3.</p>
+   <p>TODO: Protect against TLS replay, esp. if we enable early data.</p>
+   <h4 class="heading settled" data-level="8.5.3" id="remote-active-mitigations"><span class="secno">8.5.3. </span><span class="content">Remote active network attackers</span><a class="self-link" href="#remote-active-mitigations"></a></h4>
+   <p>Unfortunately, we cannot rely on network devices to fully protect Open Screen
+controllers and receivers from traffic from the broader Internet.  Open Screen
+Protocol implementations that are only intended to work on the LAN should filter
+packets from non-local IP addresses.  Implementations can also use the ARP cache
+to detect attempts to spoof local network IP addresses.</p>
+   <p>TODO: Fill in more details here.</p>
+   <h4 class="heading settled" data-level="8.5.4" id="denial-of-service-mitigations"><span class="secno">8.5.4. </span><span class="content">Denial of service</span><a class="self-link" href="#denial-of-service-mitigations"></a></h4>
+   <p>It will be difficult to completely prevent denial service of attacks that
+originate on the user’s local area network.  Open Screen Protocol
+implementations can refuse new connections, rate limit the rate of messages from
+existing connections, or limit the number of mDNS records cached in an attempt
+to allow existing activities to continue in spite of such an attack.</p>
+   <h4 class="heading settled" data-level="8.5.5" id="malicious-input-mitigations"><span class="secno">8.5.5. </span><span class="content">Malicious input</span><a class="self-link" href="#malicious-input-mitigations"></a></h4>
+   <p>Open Screen Protocol implementations should be robust against malicious input
+that attempts to compromise the target device by exploiting parsing
+vulnerabilities.</p>
+   <p>CBOR is intended to be less vulnerable to such attacks relative to alternatives
+like JSON and XML.  Still, implementations should be thoroughly tested using
+approaches like <a href="https://en.wikipedia.org/wiki/Fuzzing">fuzz testing</a>.</p>
+   <p>Where possible, Open Screen Protocol implementations (including the content
+rendering components) should use defense-in-depth techniques like <a href="https://en.wikipedia.org/wiki/Sandbox_(computer_security">sandboxing</a>).
+to prevent vulnerabilities from gaining access to user data or leading to
+persistent exploits.</p>
    <h2 class="heading settled" id="appendix-a"><span class="content">Appendix A: Messages</span><a class="self-link" href="#appendix-a"></a></h2>
    <p>The following messages are defined with <a data-link-type="biblio" href="#biblio-cddl">[CDDL]</a>. When
 integer keys are used, a comment is appended to the line to indicate
@@ -2371,6 +2551,12 @@ result = (
 })();
 </script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <aside class="dfn-panel" data-for="term-for-dom-worker-postmessage">
+   <a href="https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage">https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-worker-postmessage">8.1.4. Same-Origin Policy Violations</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-media-element">
    <a href="https://www.w3.org/TR/html51/single-page.html#media-element">https://www.w3.org/TR/html51/single-page.html#media-element</a><b>Referenced in:</b>
    <ul>
@@ -2381,6 +2567,8 @@ result = (
    <a href="https://w3c.github.io/presentation-api/#presentationconnection">https://w3c.github.io/presentation-api/#presentationconnection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-presentationconnection">2.1. Presentation API Requirements</a> <a href="#ref-for-presentationconnection①">(2)</a>
+    <li><a href="#ref-for-presentationconnection②">8.1.4. Same-Origin Policy Violations</a>
+    <li><a href="#ref-for-presentationconnection③">8.3. Presentation API Considerations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-available-presentation-display">
@@ -2419,6 +2607,7 @@ result = (
    <a href="https://w3c.github.io/presentation-api/#dfn-presentation-id">https://w3c.github.io/presentation-api/#dfn-presentation-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-presentation-id">2.1. Presentation API Requirements</a> <a href="#ref-for-dfn-presentation-id①">(2)</a> <a href="#ref-for-dfn-presentation-id②">(3)</a>
+    <li><a href="#ref-for-dfn-presentation-id③">8.1.4. Same-Origin Policy Violations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-presentation-request-url">
@@ -2456,6 +2645,11 @@ result = (
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-dom-worker-postmessage" style="color:initial">postMessage()</span>
+    </ul>
+   <li>
     <a data-link-type="biblio">[html51]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-media-element" style="color:initial">media element</span>
@@ -2484,6 +2678,8 @@ result = (
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
+   <dt id="biblio-html">[HTML]
+   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-html51">[HTML51]
    <dd>Steve Faulkner; et al. <a href="https://www.w3.org/TR/html51/">HTML 5.1 2nd Edition</a>. 3 October 2017. REC. URL: <a href="https://www.w3.org/TR/html51/">https://www.w3.org/TR/html51/</a>
    <dt id="biblio-presentation-api">[PRESENTATION-API]
@@ -2505,6 +2701,8 @@ result = (
    <dd>S. Cheshire; M. Krochmal. <a href="https://tools.ietf.org/html/rfc6762">Multicast DNS</a>. February 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6762">https://tools.ietf.org/html/rfc6762</a>
    <dt id="biblio-rfc6763">[RFC6763]
    <dd>S. Cheshire; M. Krochmal. <a href="https://tools.ietf.org/html/rfc6763">DNS-Based Service Discovery</a>. February 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6763">https://tools.ietf.org/html/rfc6763</a>
+   <dt id="biblio-security-privacy-questionnaire">[SECURITY-PRIVACY-QUESTIONNAIRE]
+   <dd>Mike West. <a href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire: Security and Privacy</a>. 10 December 2015. NOTE. URL: <a href="https://www.w3.org/TR/security-privacy-questionnaire/">https://www.w3.org/TR/security-privacy-questionnaire/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version a816d78e14132d4d4d2ee44ccaf1b8bc90ac75d5" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="366fde95a501e55aff3123d8c2117a22e77b76a3" name="document-revision">
+  <meta content="7d6057c4f01337bc8587be49103d692e8763f904" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1403,7 +1403,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-02">2 November 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-12-28">28 December 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1442,27 +1442,31 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li><a href="#requirements-remote-playback"><span class="secno">2.2</span> <span class="content">Remote Playback API Requirements</span></a>
       <li><a href="#requirements-non-functional"><span class="secno">2.3</span> <span class="content">Non-Functional Requirements</span></a>
      </ol>
-    <li><a href="#discovery"><span class="secno">3</span> <span class="content">Receiver Discovery</span></a>
-    <li><a href="#transport"><span class="secno">4</span> <span class="content">Transport Establishment</span></a>
-    <li><a href="#authentication"><span class="secno">5</span> <span class="content">Authentication</span></a>
+    <li><a href="#discovery"><span class="secno">3</span> <span class="content">Discovery with mDNS</span></a>
+    <li><a href="#transport"><span class="secno">4</span> <span class="content">Transport and metadata discovery with QUIC</span></a>
+    <li><a href="#control"><span class="secno">5</span> <span class="content">Messages delivery using CBOR and QUIC streams</span></a>
+    <li><a href="#authentication"><span class="secno">6</span> <span class="content">Authentication</span></a>
     <li>
-     <a href="#control"><span class="secno">6</span> <span class="content">Control Protocols</span></a>
+     <a href="#control①"><span class="secno">7</span> <span class="content">Control Protocols</span></a>
      <ol class="toc">
-      <li><a href="#presentation-api"><span class="secno">6.1</span> <span class="content">Presentation API Protocol</span></a>
-      <li><a href="#remote-playback"><span class="secno">6.2</span> <span class="content">Remote Playback API Protocol</span></a>
+      <li><a href="#presentation-protocol"><span class="secno">7.1</span> <span class="content">Presentation Protocol</span></a>
+      <li><a href="#presentation-api"><span class="secno">7.2</span> <span class="content">Presentation API</span></a>
+      <li><a href="#remote-playback"><span class="secno">7.3</span> <span class="content">Remote Playback API Protocol</span></a>
      </ol>
     <li>
-     <a href="#security"><span class="secno">7</span> <span class="content">Security and Privacy</span></a>
+     <a href="#security"><span class="secno">8</span> <span class="content">Security and Privacy</span></a>
      <ol class="toc">
-      <li><a href="#presentation-api-security-and-privacy"><span class="secno">7.1</span> <span class="content">Presentation API Security and Privacy</span></a>
-      <li><a href="#remote-playback-api-security-and-privacy"><span class="secno">7.2</span> <span class="content">Remote Playback API Security and Privacy</span></a>
-      <li><a href="#security-threat"><span class="secno">7.3</span> <span class="content">Threat Models</span></a>
-      <li><a href="#passive-attacks"><span class="secno">7.4</span> <span class="content">Passive Attacks</span></a>
-      <li><a href="#active-attacks"><span class="secno">7.5</span> <span class="content">Active Attacks</span></a>
-      <li><a href="#denial-of-service"><span class="secno">7.6</span> <span class="content">Denial of Service</span></a>
-      <li><a href="#security-data"><span class="secno">7.7</span> <span class="content">Data to be secured</span></a>
-      <li><a href="#security-mitigation"><span class="secno">7.8</span> <span class="content">Mitigation Strategies</span></a>
+      <li><a href="#presentation-api①"><span class="secno">8.1</span> <span class="content">Presentation API</span></a>
+      <li><a href="#remote-playback-api"><span class="secno">8.2</span> <span class="content">Remote Playback API</span></a>
+      <li><a href="#open-screen-protocol"><span class="secno">8.3</span> <span class="content">Open Screen Protocol</span></a>
+      <li><a href="#security-threat"><span class="secno">8.4</span> <span class="content">Threat Models</span></a>
+      <li><a href="#passive-attacks"><span class="secno">8.5</span> <span class="content">Passive Attacks</span></a>
+      <li><a href="#active-attacks"><span class="secno">8.6</span> <span class="content">Active Attacks</span></a>
+      <li><a href="#denial-of-service"><span class="secno">8.7</span> <span class="content">Denial of Service</span></a>
+      <li><a href="#security-data"><span class="secno">8.8</span> <span class="content">Data to be secured</span></a>
+      <li><a href="#security-mitigation"><span class="secno">8.9</span> <span class="content">Mitigation Strategies</span></a>
      </ol>
+    <li><a href="#appending-a-messages"><span class="secno">9</span> <span class="content">Appending A: Messages</span></a>
     <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
@@ -1473,6 +1477,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
      <ol class="toc">
       <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
+      <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
      </ol>
     <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
    </ol>
@@ -1493,7 +1498,7 @@ Groups</a>.</p>
    <p>The Open Screen Protocol connects browsers to devices capable of rendering Web
 content for a shared audience.  Typically, these are devices like
 Internet-connected TVs, HDMI dongles, or "smart" speakers.</p>
-   <p>The protocol is suite of subsidiary network protocols that enable two user
+   <p>The protocol is a suite of subsidiary network protocols that enable two user
 agents to implement the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> and <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> in an interoperable fashion.  This means
 that a user can expect these APIs work as intended when connecting two devices
 from independent implementations of the Open Screen Protocol.</p>
@@ -1526,6 +1531,8 @@ rendering the content of a <a data-link-type="dfn" href="https://www.w3.org/TR/h
 is called the <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-remote-playback-device" id="ref-for-dfn-remote-playback-device">remote playback device</a>.</p>
    <p>For additional terms and idioms specific to the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> or
 Remote Playback API, please consult the respective specifications.</p>
+   <p>We also use the term "agent" to mean any implementation of this protocol,
+browser, device, or otherwise, acting as a controller or a receiver.</p>
    <h2 class="heading settled" data-level="2" id="requirements"><span class="secno">2. </span><span class="content">Requirements</span><a class="self-link" href="#requirements"></a></h2>
    <h3 class="heading settled" data-level="2.1" id="requirements-presentation-api"><span class="secno">2.1. </span><span class="content">Presentation API Requirements</span><a class="self-link" href="#requirements-presentation-api"></a></h3>
    <ol>
@@ -1633,28 +1640,336 @@ transport levels) with optional features not defined explicitly by the
 specification, to facilitate experimentation and enhancement of the base
 APIs.</p>
    </ol>
-   <h2 class="heading settled" data-level="3" id="discovery"><span class="secno">3. </span><span class="content">Receiver Discovery</span><a class="self-link" href="#discovery"></a></h2>
-   <p class="issue" id="issue-b7e254cb"><a class="self-link" href="#issue-b7e254cb"></a> Incorporate material from the <a href="mdns.md">mDNS</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/100">&lt;https://github.com/webscreens/openscreenprotocol/issues/100></a></p>
-   <h2 class="heading settled" data-level="4" id="transport"><span class="secno">4. </span><span class="content">Transport Establishment</span><a class="self-link" href="#transport"></a></h2>
-   <p class="issue" id="issue-e6fb7d40"><a class="self-link" href="#issue-e6fb7d40"></a> Incorporate material from the <a href="quic.md">QUIC</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/101">&lt;https://github.com/webscreens/openscreenprotocol/issues/101></a></p>
-   <h2 class="heading settled" data-level="5" id="authentication"><span class="secno">5. </span><span class="content">Authentication</span><a class="self-link" href="#authentication"></a></h2>
+   <h2 class="heading settled" data-level="3" id="discovery"><span class="secno">3. </span><span class="content">Discovery with mDNS</span><a class="self-link" href="#discovery"></a></h2>
+   <p>Agents may discover one another using <a data-link-type="biblio" href="#biblio-rfc6763">DNS-SD</a> over <a data-link-type="biblio" href="#biblio-rfc6762">mDNS</a>.
+To do so, agents must use the service name "_openscreen._udp.local".</p>
+   <p>Advertising Agents must use an instance name that is a prefix of the agent’s
+display name. If the instance name is not the complete display name (if it has
+been truncated), it must be terminated by a null character.  It is prefix so
+that the name displayed to the user pre-verification can be verified later.  It
+is terminated by a null character in the case of truncation so that the
+listening agent knows it has been truncated.  This complexity is necessary to
+all for display names that exceed the size allowed in an instance name and for
+such (possibly  truncated) display names to be visible to the user sooner
+(before a QUIC connection is made).  Listening agents must treat instance names
+as unverified and must verify that the instance name is a prefix of the verified
+display name before showing the user a verified display name.</p>
+   <p>Advertising agents must include DNS TXT records with the following
+keys and values:</p>
+   <ul>
+    <li data-md>
+     <p>key "fp" with value of the certificate fingerpint of the advertising agent.
+The format of the fingerprint is defined by <a href="https://tools.ietf.org/html/rfc8122#section-5">RFC 8122 section
+5</a>, excluding the
+"fingerprint:" prefix and including the hash function, space, and hex-encoded
+fingerprint.  The fingerprint value also functions as an ID for the agent.
+All agents must support the following hash functions: "sha-256", "sha-512".
+Agents must not support the following hash functions: "md2", "md5".</p>
+    <li data-md>
+     <p>key "mv" with an unsigned integer value that indicates that
+metadata has changed.   The advertising agent must update it to a greater
+value.  This signals to the listening agent that it should connect to the
+advertising agent to discover updated metadata.</p>
+   </ul>
+   <p>Future extensions to this QUIC-based protocol can use the same metadata
+discovery process to indicate support for those extensions, through a
+capabilities mechanism to be determined. If a future version of the Open Screen
+Protocol uses mDNS but breaks compatibility with the metadata discovery process,
+it should change the DNS-SD service name to a new value, indicating a new
+mechanism for metadata discovery.</p>
+   <h2 class="heading settled" data-level="4" id="transport"><span class="secno">4. </span><span class="content">Transport and metadata discovery with QUIC</span><a class="self-link" href="#transport"></a></h2>
+   <p>If a listening agent wants to connect to an advertising agent, or to
+learn further metadata about it, it initiates a <a data-link-type="biblio" href="#biblio-quic">[QUIC]</a> connection to
+the IP and port from the SRV record.  Prior to authentication, a message may be
+exchanged (such as further metadata), but such info should be treated as
+unverified (such as indicating to a user that a display name of an
+unauthenticated agent is unverified).</p>
+   <p>To learn further metadata, an agent may send an agent-info-request
+message (see Appendix A) and receive back an agent-info-response message.  The
+messages may contain the following information with the following meaning:</p>
+   <ul>
+    <li data-md>
+     <p>display-name: (required) The display name of the responding agent intended
+to be displayed to a user by the requesting agent.  If the responding agent
+is not yet authenticated, the requesting agent should make UI affordance for
+indicating to the user that the display name is not yet verified.  If the
+responding agent changes its display name, the requesting agent should
+make UI affordance for indicating to the user that the display name has
+changed.</p>
+    <li data-md>
+     <p>model-name: (optional) If the agent is a hardware device, the model name of
+the device.  This is used mainly for debugging purposes, but may be
+displayed to the user of the requesting agent.</p>
+   </ul>
+   <p>Listening agents act as QUIC clients.  Advertising agents act as QUIC servers.</p>
+   <p>If a listening agent wishes to receive messages from an advertising agent or an
+advertising agent wishes to send messages to a listening agent, it may wish to
+keep the QUIC connection alive.  Once neither side needs to keep the connection
+alive for the purposes of sending or receiving messages, the connection should
+be closed with an error code of 5139.  In order to keep a QUIC connection alive, an
+agent may send an agent-status-request message, and any agent that receives an
+agent-status-request message should send an agent-status-response message. Such
+messages should be sent more frequently than the QUIC idle_timeout transport
+parameter (see section 18 of <a data-link-type="biblio" href="#biblio-quic">[QUIC]</a>) and QUIC PING
+frames should not be used.  An idle_timeout transport parameter of 25 seconds is
+recommended.  The agent should behave as though a timer less than the
+idle_timeout were reset every time a message is sent on a QUIC stream.  If the
+timer expires, a agent-status-request message should be sent.</p>
+   <p>If a client agent wishes to send messages to a server agent, the client
+agent can connect to the server agent "on demand"; it does not need to
+keep the connection alive.</p>
+   <p>The agent-info-response message and agent-status-response
+messages may be extended to include additional information not defined
+in this spec.  If done ad hoc by applications and not in future specs,
+keys should be chosen to avoid collision, such as by choosing large
+integers or long strings.  Agents must ignore keys in the
+agent-info-message that it does not understand to allow agents
+to easily extend this message.</p>
+   <h2 class="heading settled" data-level="5" id="control"><span class="secno">5. </span><span class="content">Messages delivery using CBOR and QUIC streams</span><a class="self-link" href="#control"></a></h2>
+   <p>Messages are serialized using <a data-link-type="biblio" href="#biblio-rfc7049">CBOR</a>.  To
+send a group of messages in order, that group of messages must be sent in one
+QUIC stream.  Independent groups of messages (with no ordering dependency
+across groups) should be sent in different QUIC streams.  In order to put
+multiple CBOR-serialized messages into the the same QUIC stream, the following
+is used.</p>
+   <p>For each message, the sender must write to the QUIC stream the following:</p>
+   <ol>
+    <li data-md>
+     <p>A type key representing the type of the message, encoded as a variable-length
+integer (see Appendix A for type keys)</p>
+    <li data-md>
+     <p>The message length encoded as a variable-length integer</p>
+    <li data-md>
+     <p>The messge encoded as CBOR (whose length must match the value in step 2)</p>
+   </ol>
+   <p>If an agent receives a message for which it does not recognize a
+type key, it must close the QUIC connection with an application error
+code of 404 and should include the unknown type key in the reason phrase
+(see <a data-link-type="biblio" href="#biblio-quic">[QUIC]</a> section 19.4).</p>
+   <p>Variable-length integers are encoded in the same format as defined by <a href="https://tools.ietf.org/html/draft-ietf-quic-transport-16#section-16">QUIC
+transport section
+16</a>.</p>
+   <p>Many messages are requests and responses, so a common format is defined for
+those.  A request and a response includes a request ID which is an unsigned
+integer chosen by the requester.  Responses must include the request ID of the
+request they are associated with.</p>
+   <h2 class="heading settled" data-level="6" id="authentication"><span class="secno">6. </span><span class="content">Authentication</span><a class="self-link" href="#authentication"></a></h2>
    <p class="issue" id="issue-7d8c18ff"><a class="self-link" href="#issue-7d8c18ff"></a> Incorporate material from the <a href="j-pake.md">J-PAKE</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/102">&lt;https://github.com/webscreens/openscreenprotocol/issues/102></a></p>
-   <h2 class="heading settled" data-level="6" id="control"><span class="secno">6. </span><span class="content">Control Protocols</span><a class="self-link" href="#control"></a></h2>
+   <h2 class="heading settled" data-level="7" id="control①"><span class="secno">7. </span><span class="content">Control Protocols</span><a class="self-link" href="#control①"></a></h2>
    <p class="issue" id="issue-35428ee4"><a class="self-link" href="#issue-35428ee4"></a> Describe CBOR based mechanism for
 exchanging control messages, results, and events. <a href="https://github.com/webscreens/openscreenprotocol/issues/77">&lt;https://github.com/webscreens/openscreenprotocol/issues/77></a></p>
-   <h3 class="heading settled" data-level="6.1" id="presentation-api"><span class="secno">6.1. </span><span class="content">Presentation API Protocol</span><a class="self-link" href="#presentation-api"></a></h3>
-   <p class="issue" id="issue-7e667595"><a class="self-link" href="#issue-7e667595"></a> Incorporate material from the <a href="protocol.md">Protocol</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/55">&lt;https://github.com/webscreens/openscreenprotocol/issues/55></a></p>
-   <h3 class="heading settled" data-level="6.2" id="remote-playback"><span class="secno">6.2. </span><span class="content">Remote Playback API Protocol</span><a class="self-link" href="#remote-playback"></a></h3>
+   <h3 class="heading settled" data-level="7.1" id="presentation-protocol"><span class="secno">7.1. </span><span class="content">Presentation Protocol</span><a class="self-link" href="#presentation-protocol"></a></h3>
+   <p>This section defines the use of the Open Screen Protocol for starting,
+stopping, and controlling presenetations as defined by <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a>.  A subsequent section will
+define how APIs in <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> map to the
+protocol messages defined in this section.</p>
+   <p>For all messages defined in this section, see Appendix A for the full
+CDDL definitions.</p>
+   <p>To learn which receivers are <a data-link-type="dfn">available presentation display</a>s for a
+particular URL or set of URLs, the controller may send a
+presentation-url-availability-request message with the following values:</p>
+   <ul>
+    <li data-md>
+     <p>urls: A list of presentation URLs.  Must not be empty.</p>
+    <li data-md>
+     <p>watch-duration: The period of time that the controller is interested in
+receiving updates about the URLs, should the availability change.</p>
+    <li data-md>
+     <p>watch-id: An identifier the receiver may use when sending updates about URL
+availability so that controller knows which URLs the receiver is referring
+to.</p>
+   </ul>
+   <p>In response, the receiver should send one presentation-url-availability-response
+message with the following values:</p>
+   <ul>
+    <li data-md>
+     <p>url-availabilities: A list of URL availability states (available,
+unavailable, or invalid).  Each state must correspond to the matching URL
+from the request by list index.</p>
+   </ul>
+   <p>The receivers should later (up to the current time plus request
+watch-duration) send presentation-url-availability-event messages if
+URL availabilities change.  Such events contain the following values:</p>
+   <ul>
+    <li data-md>
+     <p>watch-id: The watch-id given in the presentation-url-availability-response,
+used to refer to the presentation URLs whose availability has changed.</p>
+    <li data-md>
+     <p>url-availabilities: A list of URL availability states (available,
+unavailable, or invalid).  Each state must correspond to the URLs from the
+request referred to by the watch-id.</p>
+   </ul>
+   <p>Note that these messages are not broadcasted to all controllers. They are sent
+individually to controllers that have requested availability for the URLs that
+have changed in availability state within the watch duration of the original
+availability request.</p>
+   <p>To save power, the controller may disconnect the QUIC connection and
+later reconnect to send availablity requests and receive availability
+responses and updates.</p>
+   <p>To start a presentation, the controller may send a
+presentation-start-request message to the receiver with the following
+values:</p>
+   <ul>
+    <li data-md>
+     <p>presentation-id: the presentation identifier</p>
+    <li data-md>
+     <p>url: the selected presentation URL</p>
+    <li data-md>
+     <p>headers: headers that the receiver should use to fetch the
+presentationUrl.  For example, section 6.6.1 of <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> says that the Accept-Language
+header should be provided.</p>
+   </ul>
+   <p>The presentation ID must follow the restrictions defined by <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> section 6.1, in that it must
+consist of at least 16 ASCII characters.</p>
+   <p>When the receiver receives the presentation-start-request, it should send back a
+presentation-start-response message after either the presentation URL has been
+feteched and loaded, or the receiver has failed to do so. If it has failed, it
+must respond with the appropriate result (such as invalid-url or timeout).  If
+it has succeeded, it must reply with a success result.  Additionally, the
+response must include the following:</p>
+   <ul>
+    <li data-md>
+     <p>connection-id: An ID that both agents can use to send connection messages
+to each other.  It is chosen by the receiver for ease of implementation: if
+the message receiver chooses the connection-id, it may keep the ID unique
+across connections, thus making message demuxing/routing easier.</p>
+   </ul>
+   <p>To send a presentation message, the controller or receiver may send a
+presentation-connection-message with the following values:</p>
+   <ul>
+    <li data-md>
+     <p>connection-id: The ID from the presentation-start-response or
+presentation-connection-open-response messages.</p>
+    <li data-md>
+     <p>message: the presentation message data.</p>
+   </ul>
+   <p>To terminate a presentation, the controller may send a
+presentation-termination-request message with the following values:</p>
+   <ul>
+    <li data-md>
+     <p>presentation-id: The ID of the presentation to terminate.</p>
+    <li data-md>
+     <p>reason: The reason the presentation is being terminated.</p>
+   </ul>
+   <p>When a receiving agent receives a presentation-termination-request, it should
+send back a presentation-termination-response message to the requesting
+agent.  It should also notify other controllers about the termination by sending
+a presentation-termination-event message.  And it can send the same message if
+it terminates a presentation without a request from a controller to do so. This
+message contains the following values:</p>
+   <ul>
+    <li data-md>
+     <p>presentation-id: The ID of the presentation that was terminated.</p>
+    <li data-md>
+     <p>reason: The reason the presentation was terminated.</p>
+   </ul>
+   <p>To accept incoming connections requests from controller, a receiver
+must receive and process the presentation-connection-open-request
+message which contains the following values:</p>
+   <ul>
+    <li data-md>
+     <p>presentation-id: The ID of the presentation to connect to.</p>
+    <li data-md>
+     <p>url: The URL of the presentation to connect to.</p>
+   </ul>
+   <p>The receiver should, upon receipt of a
+presentation-connection-open-request message, send back a
+presentation-connection-open-response message which contains the
+following values:</p>
+   <ul>
+    <li data-md>
+     <p>result: a code indicating success or failure, and the reason for the failure</p>
+    <li data-md>
+     <p>connection-id: An ID that both agents can use to send connection messages
+to each other.  It is chosen by the receiver for ease of implementation (if
+the message receiver chooses the connection-id, it may keep the ID unique
+across connections, thus making message demuxing/routing easier).</p>
+   </ul>
+   <p>A controller may terminate a connection without terminating the presentation by
+sending a presentation-connection-close-request message with the following
+values:</p>
+   <ul>
+    <li data-md>
+     <p>connection-id: The ID of the connection to close.</p>
+   </ul>
+   <p>The receiver should, upon receipt of a presentation-connection-close-request,
+send back a presentation-connection-close-response message with the following
+values:</p>
+   <ul>
+    <li data-md>
+     <p>result: If the close succeed or failed, and if it failed why it failed.</p>
+   </ul>
+   <p>The receiver may also close a connection without a request from the controller
+to do so and without terminating a presentation.  If it does so, it should send
+a presentation-connection-close-event to the controller with the following
+values:</p>
+   <ul>
+    <li data-md>
+     <p>connection-id: The ID of the connection that was closed</p>
+    <li data-md>
+     <p>reason: The reason the connection was closed</p>
+    <li data-md>
+     <p>error-message: A debug message suitable for a log or perhaps presented to
+the user with more explanation as to why it was closed.</p>
+   </ul>
+   <h3 class="heading settled" data-level="7.2" id="presentation-api"><span class="secno">7.2. </span><span class="content">Presentation API</span><a class="self-link" href="#presentation-api"></a></h3>
+   <p>This section defines how <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> uses
+the messages defined in the previous sections.
+Non-browser agents can also send and receive the same messages defined here.
+If so, a non-browser agent must follow the same restrictions for the
+presentation-id as the a does, as defined by <a data-link-type="biblio" href="#biblio-presentation-api">Presentation
+API</a> section 6.1 (at least 16 ASCII characters).</p>
+   <p>When <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> <a href="https://www.w3.org/TR/presentation-api/#sending-a-message-through-presentationconnection">section
+6.4.2</a> says "This list of presentation displays ... is populated based on an
+implementation specific discovery mechanism", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent" id="ref-for-dfn-controlling-user-agent③">controlling user
+agent</a> may use the mDNS, QUIC, agent-info-request, and
+presentation-url-availability-request messages defined previously in
+this spec to discover receivers.</p>
+   <p>When <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> <a href="https://www.w3.org/TR/presentation-api/#the-list-of-available-presentation-displays">section
+6.4.2</a> says "To further save power, ... implementation specific discovery of
+presentation displays can be resumed or suspended.", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent" id="ref-for-dfn-controlling-user-agent④">controlling
+user agent</a> may use the power saving mechanism defined in the
+previous section.</p>
+   <p>When <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> <a href="https://www.w3.org/TR/presentation-api/#starting-a-presentation-connection">section
+6.3.4</a> says "Using an implementation specific mechanism, tell U to create a
+receiving browsing context with D, presentationUrl, and I as
+parameters.", U (the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent" id="ref-for-dfn-controlling-user-agent⑤">controlling user agent</a>) may send a
+presentation-start-request message to D (the receiver), with I for the
+presentation identifier and presentationUrl for the selected
+presentation URL.</p>
+   <p>When <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> <a href="https://www.w3.org/TR/presentation-api/#sending-a-message-through-presentationconnection">section
+6.5.2</a> says "Using an implementation specific mechanism, transmit the
+contents of messageOrData as the presentation message data and
+messageType as the presentation message type to the destination
+browsing context", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent" id="ref-for-dfn-controlling-user-agent⑥">controlling user agent</a> may send a
+presentation-connection-message with messageOrData for the
+presentation message data.  Note that the messageType is embedded in
+the encoded CBOR type and does not need an additional value in the
+message.</p>
+   <p>When <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> <a href="https://www.w3.org/TR/presentation-api/#terminating-a-presentation-in-a-controlling-browsing-context">section
+6.5.6</a> says "Send a termination request for the presentation to its receiving user
+agent using an implementation specific mechanism", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent" id="ref-for-dfn-controlling-user-agent⑦">controlling user
+agent</a> may send a presentation-termination-request message.</p>
+   <p>When <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> <a href="https://www.w3.org/TR/presentation-api/#monitoring-incoming-presentation-connections">section
+6.7.1</a> says "it MUST listen to and accept incoming connection requests from a
+controlling browsing context using an implementation specific
+mechanism", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent" id="ref-for-dfn-receiving-user-agent①">receiving user agent</a> must receive and process the
+presentation-connection-open-request.</p>
+   <p>When <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> <a href="https://www.w3.org/TR/presentation-api/#monitoring-incoming-presentation-connections">section
+6.7.1</a> says "Establish the connection between the controlling and receiving browsing
+contexts using an implementation specific mechanism.", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent" id="ref-for-dfn-receiving-user-agent②">receiving user
+agent</a>, must send a presentation-connection-open-response message.</p>
+   <h3 class="heading settled" data-level="7.3" id="remote-playback"><span class="secno">7.3. </span><span class="content">Remote Playback API Protocol</span><a class="self-link" href="#remote-playback"></a></h3>
    <p class="issue" id="issue-eaed3698"><a class="self-link" href="#issue-eaed3698"></a> Propose control protocol for Remote
 Playback API. <a href="https://github.com/webscreens/openscreenprotocol/issues/12">&lt;https://github.com/webscreens/openscreenprotocol/issues/12></a></p>
-   <h2 class="heading settled" data-level="7" id="security"><span class="secno">7. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security"></a></h2>
+   <h2 class="heading settled" data-level="8" id="security"><span class="secno">8. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security"></a></h2>
    <p>The Open Screen Protocol should, at a minimum, conform to the security and
 privacy guidelines recommended by the [[PRESENTATION-API][Presentation API]] and
 the [[REMOTE-PLAYBACK][Remote Playback API]].</p>
-   <p>In addition, the Open Screen Protocol itself has additional security and privacy
+   <p>In addition, the Open Screen Protocol itself adds additional security and privacy
 considerations.</p>
-   <h3 class="heading settled" data-level="7.1" id="presentation-api-security-and-privacy"><span class="secno">7.1. </span><span class="content">Presentation API Security and Privacy</span><a class="self-link" href="#presentation-api-security-and-privacy"></a></h3>
-   <p>The [[PRESENTATION-API#security-and-privacy-considerations][Presentation API
+   <h3 class="heading settled" data-level="8.1" id="presentation-api①"><span class="secno">8.1. </span><span class="content">Presentation API</span><a class="self-link" href="#presentation-api①"></a></h3>
+   <p>[[PRESENTATION-API#security-and-privacy-considerations][Presentation API
 Security and Privacy Considerations]] place these requirements on the Open
 Screen Protocol:</p>
    <ol>
@@ -1670,18 +1985,19 @@ been made to a presentation, per the user interface guidelines.</p>
 confidential, per the guidelines for messaging between presentation
 connections.</p>
    </ol>
-   <h3 class="heading settled" data-level="7.2" id="remote-playback-api-security-and-privacy"><span class="secno">7.2. </span><span class="content">Remote Playback API Security and Privacy</span><a class="self-link" href="#remote-playback-api-security-and-privacy"></a></h3>
+   <h3 class="heading settled" data-level="8.2" id="remote-playback-api"><span class="secno">8.2. </span><span class="content">Remote Playback API</span><a class="self-link" href="#remote-playback-api"></a></h3>
    <p>The [[REMOTE-PLAYBACK#security-and-privacy-considerations][Remote Playback API
 Security and Privacy Considerations]] also state that messaging between local
 and remote playback devices should also be authenticated and confidential.</p>
-   <h3 class="heading settled" data-level="7.3" id="security-threat"><span class="secno">7.3. </span><span class="content">Threat Models</span><a class="self-link" href="#security-threat"></a></h3>
-   <h3 class="heading settled" data-level="7.4" id="passive-attacks"><span class="secno">7.4. </span><span class="content">Passive Attacks</span><a class="self-link" href="#passive-attacks"></a></h3>
+   <h3 class="heading settled" data-level="8.3" id="open-screen-protocol"><span class="secno">8.3. </span><span class="content">Open Screen Protocol</span><a class="self-link" href="#open-screen-protocol"></a></h3>
+   <h3 class="heading settled" data-level="8.4" id="security-threat"><span class="secno">8.4. </span><span class="content">Threat Models</span><a class="self-link" href="#security-threat"></a></h3>
+   <h3 class="heading settled" data-level="8.5" id="passive-attacks"><span class="secno">8.5. </span><span class="content">Passive Attacks</span><a class="self-link" href="#passive-attacks"></a></h3>
    <p>The Open Screen Protocol should assume that all parties that are able
 access the LAN, either through a wired connection or through WiFi, are able to
 observe all data flowing between Open Screen controllers and receivers.</p>
    <p>These parties will be able collect any data exposed through unencrypted
 messages, such as mDNS records and the QUIC handshake.</p>
-   <h3 class="heading settled" data-level="7.5" id="active-attacks"><span class="secno">7.5. </span><span class="content">Active Attacks</span><a class="self-link" href="#active-attacks"></a></h3>
+   <h3 class="heading settled" data-level="8.6" id="active-attacks"><span class="secno">8.6. </span><span class="content">Active Attacks</span><a class="self-link" href="#active-attacks"></a></h3>
    <p>In addition, all parties with access to the LAN will be able to manipulate data
 exchanged between controllers and receivers and inititate QUIC connections.
 This can be used to attempt attacks such as:</p>
@@ -1691,10 +2007,10 @@ This can be used to attempt attacks such as:</p>
 to convince the user to authenticate it as a trusted receiver.</p>
     <li data-md>
      <p>Connecting to a receiver and querying its capabilities, or attempting to
-connect to a running presentation or remote playback.</p>
+xconnect to a running presentation or remote playback.</p>
    </ul>
-   <h3 class="heading settled" data-level="7.6" id="denial-of-service"><span class="secno">7.6. </span><span class="content">Denial of Service</span><a class="self-link" href="#denial-of-service"></a></h3>
-   <h3 class="heading settled" data-level="7.7" id="security-data"><span class="secno">7.7. </span><span class="content">Data to be secured</span><a class="self-link" href="#security-data"></a></h3>
+   <h3 class="heading settled" data-level="8.7" id="denial-of-service"><span class="secno">8.7. </span><span class="content">Denial of Service</span><a class="self-link" href="#denial-of-service"></a></h3>
+   <h3 class="heading settled" data-level="8.8" id="security-data"><span class="secno">8.8. </span><span class="content">Data to be secured</span><a class="self-link" href="#security-data"></a></h3>
    <p>There are two kinds of data</p>
    <ol>
     <li data-md>
@@ -1717,7 +2033,198 @@ and untrusted data:</p>
      <p>Friendly names or other data advertised through mDNS.</p>
     <li data-md>
    </ol>
-   <h3 class="heading settled" data-level="7.8" id="security-mitigation"><span class="secno">7.8. </span><span class="content">Mitigation Strategies</span><a class="self-link" href="#security-mitigation"></a></h3>
+   <h3 class="heading settled" data-level="8.9" id="security-mitigation"><span class="secno">8.9. </span><span class="content">Mitigation Strategies</span><a class="self-link" href="#security-mitigation"></a></h3>
+   <h2 class="heading settled" data-level="9" id="appending-a-messages"><span class="secno">9. </span><span class="content">Appending A: Messages</span><a class="self-link" href="#appending-a-messages"></a></h2>
+    The following messages are defined with <a data-link-type="biblio" href="#biblio-cddl">[CDDL]</a>. When
+integer keys are used, a comment is appended to the line to indicate
+the name of the field. Each root message (one that can be put into a
+QUIC stream without being inclosed by another message) has a comment
+indicating the message type key. 
+   <p>Smaller numbers should be reserved for message that will be sent more
+frequently or are very small or both and larger numbers should be
+reserved for messsages that are infrequently sent or large or both
+because smaller type keys encode on the wire smaller.</p>
+<pre>; type key 10
+agent-info-request = {
+  request
+}
+
+; type key 11
+agent-info-response = {
+  response
+  1: agent-info ; agent-info
+}
+
+agent-info = {
+  0: text ; friendly-name
+  1: text ; model-name
+  ; ...
+}
+
+; type key 12
+agent-status-request = {
+  request
+  ? 1: status ; status
+}
+
+; type key 13
+agent-status-response = {
+  response
+  ? 1: status ; status
+}
+
+status = {
+}
+
+request = (
+ 0: request-id ; request-id
+)
+
+response = (
+ 0: request-id ; request-id
+)
+
+request-id = uint
+
+; type key 14
+presentation-url-availability-request = {
+  request
+  1: [1* text] ; urls
+  2: microseconds ; watch-duration
+  3: int ; watch-id
+}
+
+; type key 15
+presentation-url-availability-response = {
+  response
+  1: [1* url-availability] ; url-availabilities
+}
+
+; type key 103
+presentation-url-availability-event = {
+  1: int ; watch-id
+  2: [1* url-availability] ; url-availabilities
+}
+
+
+; idea: use HTTP response codes?
+url-availability = &amp;(
+  available: 0
+  unavailable: 1
+  invalid: 10
+)
+
+; type key 104
+presentation-start-request = {
+  request
+  1: text ; presentation-id
+  2: text ; url
+  3: [* http-header] ; headers
+}
+
+http-header = [
+  key: text
+  value: text
+]
+
+; type key 105
+presentation-start-response = {
+  response
+  1: &amp;result ; result
+  2: uint ; connection-id
+}
+
+; type key 106
+presentation-termination-request = {
+  request
+  1: text ; presentation-id
+  2: &amp;(
+    controller-called-terminate: 10
+    user-terminated-via-controller: 11
+    unknown: 255
+  )
+ ; reason
+}
+
+; type key 107
+presentation-termination-response = {
+  response
+  1: result ; result
+}
+
+; type key 108
+presentation-termination-event = {
+  1: text ; presentation-id
+  2: &amp;(
+    receiver-called-terminate: 1
+    user-terminated-via-receiver: 2
+    controller-called-terminate: 10
+    user-terminated-via-controller: 11
+    receiver-replaced-presentation: 20
+    receiver-idle-too-long: 30
+    receiver-attempted-to-navigate: 31
+    receiver-powering-down: 100
+    receiver-crashed: 101
+    unknown: 255
+  )
+}
+
+; type key 109
+presentation-connection-open-request = {
+  request
+  1: text ; presentation-id
+  2: text ; url
+}
+
+; type key 110
+presentation-connection-open-response = {
+  response
+  1: &amp;result ; result
+  2: uint; connection-id
+}
+
+; type key 111
+presentation-connection-close-request = {
+  request
+  1: uint ; connection-id
+}
+
+; type key 112
+presentation-connection-close-response = {
+  response
+  1: &amp;result ; result
+}
+
+; type key 113
+presentation-connection-close-event = {
+  1: uint; connection-id
+  2: &amp;(
+    close-method-called: 1
+    connection-object-discarded: 10
+    unrecoverable-error-while-sending-or-receiving-message: 100
+  ) ; reason
+  ? 3: text ; error-message
+}
+
+
+; type key 16
+presentation-connection-message = {
+  1: uint ; connection-id
+  2: bytes / text ; message
+}
+
+result = (
+  success: 1
+  invalid-url: 10
+  invalid-presentation-id: 11
+  timeout: 100
+  transient-error: 101
+  permanent-error: 102
+  terminating: 103
+  unknown-error: 199
+)
+
+</pre>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -1889,6 +2396,7 @@ and untrusted data:</p>
    <ul>
     <li><a href="#ref-for-dfn-controlling-user-agent">1.1. Terminology</a> <a href="#ref-for-dfn-controlling-user-agent①">(2)</a>
     <li><a href="#ref-for-dfn-controlling-user-agent②">2.1. Presentation API Requirements</a>
+    <li><a href="#ref-for-dfn-controlling-user-agent③">7.2. Presentation API</a> <a href="#ref-for-dfn-controlling-user-agent④">(2)</a> <a href="#ref-for-dfn-controlling-user-agent⑤">(3)</a> <a href="#ref-for-dfn-controlling-user-agent⑥">(4)</a> <a href="#ref-for-dfn-controlling-user-agent⑦">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-presentation-display">
@@ -1932,6 +2440,7 @@ and untrusted data:</p>
    <a href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent">https://w3c.github.io/presentation-api/#dfn-receiving-user-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-receiving-user-agent">1.1. Terminology</a>
+    <li><a href="#ref-for-dfn-receiving-user-agent①">7.2. Presentation API</a> <a href="#ref-for-dfn-receiving-user-agent②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-remote-playback-device">
@@ -1974,20 +2483,30 @@ and untrusted data:</p>
    <dd>Steve Faulkner; et al. <a href="https://www.w3.org/TR/html51/">HTML 5.1 2nd Edition</a>. 3 October 2017. REC. URL: <a href="https://www.w3.org/TR/html51/">https://www.w3.org/TR/html51/</a>
    <dt id="biblio-presentation-api">[PRESENTATION-API]
    <dd>Mark Foltz; Dominik Röttsches. <a href="https://www.w3.org/TR/presentation-api/">Presentation API</a>. 1 June 2017. CR. URL: <a href="https://www.w3.org/TR/presentation-api/">https://www.w3.org/TR/presentation-api/</a>
+   <dt id="biblio-quic">[QUIC]
+   <dd>J. Iyengar; M. Thomson. <a href="https://tools.ietf.org/html/draft-ietf-quic-transport-16">Concise data definition language (CDDL): a notational convention to express CBOR and JSON data structures</a>. 23 October 2018. Internet Draft. URL: <a href="https://tools.ietf.org/html/draft-ietf-quic-transport-16">https://tools.ietf.org/html/draft-ietf-quic-transport-16</a>
    <dt id="biblio-remote-playback">[REMOTE-PLAYBACK]
    <dd>Mounir Lamouri; Anton Vayvod. <a href="https://www.w3.org/TR/remote-playback/">Remote Playback API</a>. 19 October 2017. CR. URL: <a href="https://www.w3.org/TR/remote-playback/">https://www.w3.org/TR/remote-playback/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-rfc7049">[RFC7049]
+   <dd>C. Bormann; P. Hoffman. <a href="https://tools.ietf.org/html/rfc7049">Concise Binary Object Representation (CBOR)</a>. October 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7049">https://tools.ietf.org/html/rfc7049</a>
+  </dl>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <dl>
+   <dt id="biblio-cddl">[CDDL]
+   <dd>H. Birkholz; C. Vigano; C. Bormann. <a href="https://datatracker.ietf.org/doc/draft-ietf-cbor-cddl/">Concise data definition language (CDDL): a notational convention to express CBOR and JSON data structures</a>. Internet Draft. URL: <a href="https://datatracker.ietf.org/doc/draft-ietf-cbor-cddl/">https://datatracker.ietf.org/doc/draft-ietf-cbor-cddl/</a>
+   <dt id="biblio-rfc6762">[RFC6762]
+   <dd>S. Cheshire; M. Krochmal. <a href="https://tools.ietf.org/html/rfc6762">Multicast DNS</a>. February 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6762">https://tools.ietf.org/html/rfc6762</a>
+   <dt id="biblio-rfc6763">[RFC6763]
+   <dd>S. Cheshire; M. Krochmal. <a href="https://tools.ietf.org/html/rfc6763">DNS-Based Service Discovery</a>. February 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6763">https://tools.ietf.org/html/rfc6763</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
    <div class="issue"> Requirements for Remote Playback API <a href="https://github.com/webscreens/openscreenprotocol/issues/3">&lt;https://github.com/webscreens/openscreenprotocol/issues/3></a><a href="#issue-a1f35a95"> ↵ </a></div>
-   <div class="issue"> Incorporate material from the <a href="mdns.md">mDNS</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/100">&lt;https://github.com/webscreens/openscreenprotocol/issues/100></a><a href="#issue-b7e254cb"> ↵ </a></div>
-   <div class="issue"> Incorporate material from the <a href="quic.md">QUIC</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/101">&lt;https://github.com/webscreens/openscreenprotocol/issues/101></a><a href="#issue-e6fb7d40"> ↵ </a></div>
    <div class="issue"> Incorporate material from the <a href="j-pake.md">J-PAKE</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/102">&lt;https://github.com/webscreens/openscreenprotocol/issues/102></a><a href="#issue-7d8c18ff"> ↵ </a></div>
    <div class="issue"> Describe CBOR based mechanism for
 exchanging control messages, results, and events. <a href="https://github.com/webscreens/openscreenprotocol/issues/77">&lt;https://github.com/webscreens/openscreenprotocol/issues/77></a><a href="#issue-35428ee4"> ↵ </a></div>
-   <div class="issue"> Incorporate material from the <a href="protocol.md">Protocol</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/55">&lt;https://github.com/webscreens/openscreenprotocol/issues/55></a><a href="#issue-7e667595"> ↵ </a></div>
    <div class="issue"> Propose control protocol for Remote
 Playback API. <a href="https://github.com/webscreens/openscreenprotocol/issues/12">&lt;https://github.com/webscreens/openscreenprotocol/issues/12></a><a href="#issue-eaed3698"> ↵ </a></div>
   </div>

--- a/index.html
+++ b/index.html
@@ -1214,11 +1214,6 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version a816d78e14132d4d4d2ee44ccaf1b8bc90ac75d5" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-<<<<<<< HEAD
-  <meta content="f33127b767855f2f47e713afde2ed716c4ed19a3" name="document-revision">
-=======
-  <meta content="46293b6c6367bb91201b5df913d784680d4d2f95" name="document-revision">
->>>>>>> Fix index.html
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1407,11 +1402,6 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-<<<<<<< HEAD
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-01-03">3 January 2019</time></span></h2>
-=======
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-01-14">14 January 2019</time></span></h2>
->>>>>>> Fix index.html
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2082,57 +2072,57 @@ agent</a>, must send a presentation-connection-open-response message.</p>
    <p class="issue" id="issue-eaed3698"><a class="self-link" href="#issue-eaed3698"></a> Propose control protocol for Remote
 Playback API. <a href="https://github.com/webscreens/openscreenprotocol/issues/12">&lt;https://github.com/webscreens/openscreenprotocol/issues/12></a></p>
    <h2 class="heading settled" data-level="8" id="security-privacy"><span class="secno">8. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security-privacy"></a></h2>
-   <p>The Open Screen Protocol allows two networked user agents to discover each other
+   <p>The Open Screen Protocol allows two networked agents to discover each other
 and exchange user and application data.  As such, its security and privacy
 considerations should be closely examined.  We first evaluate the protocol
 itself using the W3C <a data-link-type="biblio" href="#biblio-security-privacy-questionnaire">Security and Privacy
 Questionnaire</a>.  We then examine whether the security and privacy guidelines
 recommended by the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> and the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> are met.  Finally we discuss recommended
-mitigations that implementations can use to meet these security and privacy
+mitigations that agents can use to meet these security and privacy
 requirements.</p>
    <h3 class="heading settled" data-level="8.1" id="threat-models"><span class="secno">8.1. </span><span class="content">Threat Models</span><a class="self-link" href="#threat-models"></a></h3>
    <h4 class="heading settled" data-level="8.1.1" id="passive-network-attackers"><span class="secno">8.1.1. </span><span class="content">Passive Network Attackers</span><a class="self-link" href="#passive-network-attackers"></a></h4>
    <p>The Open Screen Protocol should assume that all parties that are connected to
 the same LAN, either through a wired connection or through WiFi, are able to
-observe all data flowing between Open Screen controllers and receivers.</p>
+observe all data flowing between Open Screen Protocol agents.</p>
    <p>These parties will be able collect any data exposed through unencrypted
-messages, such as mDNS records and the QUIC handshake.</p>
+messages, such as mDNS records and the QUIC handshakes.</p>
    <p>These parties may attempt to learn cryptographic parameters by observing data
 flows on the QUIC connection, or by observing cryptographic timing.</p>
    <h4 class="heading settled" data-level="8.1.2" id="active-network-attackers"><span class="secno">8.1.2. </span><span class="content">Active Network Attackers</span><a class="self-link" href="#active-network-attackers"></a></h4>
-   <p>In addition, all parties connected to the LAN will be able to manipulate data
-exchanged between controllers and receivers.  They will be able to inject
-traffic into existing QUIC connections and attempt to inititate new QUIC
-connections.  These abilities can be used to attempt the following:</p>
+   <p>Active attackers, such as compromised routers, will be able to manipulate data
+exchanged between agents.  They can inject traffic into existing QUIC
+connections and attempt to inititate new QUIC connections.  These abilities can
+be used to attempt the following:</p>
    <ul>
     <li data-md>
-     <p>Impersonate a new receiver or one already trusted by the user, in an attempt
+     <p>Impersonate an agent or one already trusted by the user, in an attempt
 to convince the user to authenticate to it.</p>
     <li data-md>
-     <p>Connect to a receiver and query its capabilities.</p>
+     <p>Connect to an agent and query its capabilities.</p>
     <li data-md>
      <p>Connect to and control a presentation or remote playback, or extract data
 from the application state of the presentation or remote playback.</p>
    </ul>
    <p>One particular attack of concern is misconfigured or compromised routers that
-expose local network devices (such as Open Screen Protocol controllers and
-receivers) to the Internet.  This vector of attack has been used by malicious
-parties to take control of printers and smart TVs by connecting to local network
-services that would normally be inaccessible from the Internet.</p>
+expose local network devices (such as Open Screen Protocol agents) to the
+Internet.  This vector of attack has been used by malicious parties to take
+control of printers and smart TVs by connecting to local network services that
+would normally be inaccessible from the Internet.</p>
    <h4 class="heading settled" data-level="8.1.3" id="denial-of-service"><span class="secno">8.1.3. </span><span class="content">Denial of Service</span><a class="self-link" href="#denial-of-service"></a></h4>
    <p>Parties with connected to the LAN may attempt to deny access to Open Screen
-Protocol controllers and receivers.  For example, an attacker my attempt to open
-a large number of QUIC connections to a receiver in an attempt to block
-legitimate connections or exhaust the receiver’s system resources.  They may
+Protocol agents.  For example, an attacker my attempt to open
+a large number of QUIC connections to an agent in an attempt to block
+legitimate connections or exhaust the agent’s system resources.  They may
 also multicast spurious DNS-SD records in an attempt to exhaust the cache
 capacity for mDNS listeners, or to get listeners to open a large number of bogus
 QUIC connections.</p>
    <h4 class="heading settled" data-level="8.1.4" id="same-origin-policy-violations"><span class="secno">8.1.4. </span><span class="content">Same-Origin Policy Violations</span><a class="self-link" href="#same-origin-policy-violations"></a></h4>
    <p>The Presentation API allows cross-origin communication between controlling pages
 and presentations with the consent of each origin (through their use of the
-API).  This is similar to cross-origin communication via <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage" id="ref-for-dom-window-postmessage">postMessage()</a></code> with a target origin of <code>*</code>.  However, the Presentation API does not convey
-source origin information with each message.  Therefore, the Open Screen
-Protocol does not convey origin information between controllers and receivers.</p>
+API).  This is similar to cross-origin communication via <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage" id="ref-for-dom-window-postmessage">postMessage()</a></code> with a target origin of <code>*</code>.  However, the Presentation
+API does not convey source origin information with each message.  Therefore, the
+Open Screen Protocol does not convey origin information between its agents.</p>
    <p>The <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-id" id="ref-for-dfn-presentation-id③">presentation ID</a> carries some protection against unrestricted
 cross-origin access; but, rigorous authentication of the parties connected by a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection②">PresentationConnection</a></code> must be done at the application level.</p>
    <h3 class="heading settled" data-level="8.2" id="security-privacy-questions"><span class="secno">8.2. </span><span class="content">Open Screen Protocol Considerations</span><a class="self-link" href="#security-privacy-questions"></a></h3>
@@ -2153,17 +2143,20 @@ and/or high value data:</p>
     <li data-md>
      <p>Remote playback commands and status messages</p>
    </ol>
+   <p>Presentation IDs are considered high value data because they can be used in
+conjunction with a Presentation URL to connect to a running presentation.</p>
    <p>Presentation display friendly names, model names, and capabilities, while not
-considered personally identifiable, is important to protect to preserve the
-integrity of the discovery and authentication process.</p>
-   <p>The following data cannot be reasonably secured and should be considered public
-and untrusted data:</p>
+considered personally identifiable, are important to protect to prevent an
+attacker from changing them or substituting other values during the discovery
+and authentication process.</p>
+   <p>The following data cannot be reasonably made confidential and should be
+considered public and untrusted data:</p>
    <ol>
     <li data-md>
      <p>IP addresses and ports used by the Open Screen Protocol.</p>
     <li data-md>
-     <p>Data advertised through mDNS, including the certificate fingerprint and the
-metadata version.</p>
+     <p>Data advertised through mDNS, including the display name prefix, the
+certificate fingerprint, and the metadata version.</p>
    </ol>
    <h4 class="heading settled" data-level="8.2.2" id="cross-origin-state"><span class="secno">8.2.2. </span><span class="content">Cross Origin State Considerations</span><a class="self-link" href="#cross-origin-state"></a></h4>
    <p>Access to origin state across browsing sessions is possible through the
@@ -2180,16 +2173,16 @@ designed accordingly.</p>
    <p>Below, we discuss mitigation steps to prevent malicious use of these devices.</p>
    <h4 class="heading settled" data-level="8.2.4" id="incognito-mode"><span class="secno">8.2.4. </span><span class="content">Incognito Mode</span><a class="self-link" href="#incognito-mode"></a></h4>
    <p>The Open Screen Protocol does not distinguish between the user agent’s normal
-browsing and incognito modes, and should operate identically regardless of which
-mode is in use.</p>
+browsing and incognito modes, and agents that follow the specification
+behave identically regardless of which mode is in use.</p>
    <p>It’s recommended that controllers use separate authentication contexts and QUIC
 connections for normal and incognito profiles from the same user agent instance.
-This prevents Open Screen receivers from correlating activity between a user’s
-normal profile and their incognito profile.</p>
+This prevents Open Screen receivers from correlating activity among a user’s
+profiles (both normal and incognito).</p>
    <h4 class="heading settled" data-level="8.2.5" id="persistent-state"><span class="secno">8.2.5. </span><span class="content">Persistent State</span><a class="self-link" href="#persistent-state"></a></h4>
-   <p>An implementation of the Open Screen Protocol is likely to persist the identity
-of controllers and receivers that have successfully completed <a href="#authentication">§6 Authentication</a>.  This may include the public key fingerprints, metadata
-versions, and metadata for those parties.</p>
+   <p>An agent is likely to persist the identity of agents that have successfully
+completed <a href="#authentication">§6 Authentication</a>.  This may include the public key fingerprints,
+metadata versions, and metadata for those parties.</p>
    <p>However, this data is not normally exposed to the Web, only through the native
 UI of the user agent during the display selection or display authentication
 process.  It can be an implementation choice whether the user agent clears or
@@ -2235,8 +2228,8 @@ connections.</p>
      <p>Requiring mutual authentication and a TLS-secured QUIC connection before
  presentation URLs, IDs, or messages are exchanged.</p>
     <li data-md>
-     <p>Adding explicit messages and connection IDs for individual <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection③">PresentationConnections</a></code> so that controllers and
- receivers can track the number of active connections.</p>
+     <p>Adding explicit messages and connection IDs for individual <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection③">PresentationConnections</a></code> so that agents can track
+ the number of active connections.</p>
    </ol>
    <h3 class="heading settled" data-level="8.4" id="remote-playback-considerations"><span class="secno">8.4. </span><span class="content">Remote Playback API Considerations</span><a class="self-link" href="#remote-playback-considerations"></a></h3>
    <p>The <a href="https://www.w3.org/TR/remote-playback/#security-and-privacy-considerations">Remote Playback API §security-and-privacy-considerations</a> also state that
@@ -2257,11 +2250,10 @@ cryptographic parameters of the TLS 1.3 QUIC connection.</p>
    <h4 class="heading settled" data-level="8.5.2" id="local-active-mitigations"><span class="secno">8.5.2. </span><span class="content">Local active network attackers</span><a class="self-link" href="#local-active-mitigations"></a></h4>
    <p>Local active attackers may attempt to impersonate a presentation display the
 user would normally trust.  The <a href="#authentication">§6 Authentication</a> step of the Open Screen
-Protocol prevents a man-in-the-middle from impersonating a controller or
-receiver, without knowledge of a shared secret.  However, it is possible for an
-attacker to impersonate an existing, trusted display or a newly discovered
-display that is not yet authenticated and try to convince the user to
-authenticate it.</p>
+Protocol prevents a man-in-the-middle from impersonating an agent, without
+knowledge of a shared secret.  However, it is possible for an attacker to
+impersonate an existing, trusted display or a newly discovered display that is
+not yet authenticated and try to convince the user to authenticate it.</p>
    <p>This can be addressed through a combination of techniques.  The first is flagging:</p>
    <ul>
     <li data-md>
@@ -2270,8 +2262,7 @@ IP:port collide with an already trusted display.</p>
     <li data-md>
      <p>Flag already-trusted displays whose metadata has changed.</p>
     <li data-md>
-     <p>Flag controllers or receivers that fail the authentication challenge a certain
-number of times.</p>
+     <p>Flag agents that fail the authentication challenge a certain number of times.</p>
    </ul>
    <p>Flagging means that the user is notified, or in some cases they are required to
 re-authenticate to the presentation display to verify its identity.</p>
@@ -2295,26 +2286,26 @@ by a correct implementation of TLS 1.3.</p>
    <p class="issue" id="issue-5107ff88①"><a class="self-link" href="#issue-5107ff88①"></a> [Security] Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a></p>
    <h4 class="heading settled" data-level="8.5.3" id="remote-active-mitigations"><span class="secno">8.5.3. </span><span class="content">Remote active network attackers</span><a class="self-link" href="#remote-active-mitigations"></a></h4>
    <p>Unfortunately, we cannot rely on network devices to fully protect Open Screen
-controllers and receivers from traffic from the broader Internet.  Open Screen
-Protocol implementations that are only intended to work on the LAN should filter
-packets from non-local IP addresses.  Implementations can also use the ARP cache
-to detect attempts to spoof local network IP addresses.</p>
+Protocol agents from traffic from the broader Internet.  Open Screen Protocol
+agents that are only intended to work on the LAN should filter packets
+from non-local IP addresses.  Agents can also use the ARP cache to
+detect attempts to spoof local network IP addresses.</p>
    <p class="issue" id="issue-1353180f"><a class="self-link" href="#issue-1353180f"></a> [Security] Mitigations for remote network attackers <a href="https://github.com/webscreens/openscreenprotocol/issues/131">&lt;https://github.com/webscreens/openscreenprotocol/issues/131></a></p>
    <h4 class="heading settled" data-level="8.5.4" id="denial-of-service-mitigations"><span class="secno">8.5.4. </span><span class="content">Denial of service</span><a class="self-link" href="#denial-of-service-mitigations"></a></h4>
    <p>It will be difficult to completely prevent denial service of attacks that
-originate on the user’s local area network.  Open Screen Protocol
-implementations can refuse new connections, rate limit the rate of messages from
-existing connections, or limit the number of mDNS records cached in an attempt
-to allow existing activities to continue in spite of such an attack.</p>
+originate on the user’s local area network.  Open Screen Protocol agents can
+refuse new connections, rate limit the rate of messages from existing
+connections, or limit the number of mDNS records cached from a specific
+responder in an attempt to allow existing activities to continue in spite of
+such an attack.</p>
    <h4 class="heading settled" data-level="8.5.5" id="malicious-input-mitigations"><span class="secno">8.5.5. </span><span class="content">Malicious input</span><a class="self-link" href="#malicious-input-mitigations"></a></h4>
-   <p>Open Screen Protocol implementations should be robust against malicious input
-that attempts to compromise the target device by exploiting parsing
-vulnerabilities.</p>
+   <p>Open Screen Protocol agents should be robust against malicious input that
+attempts to compromise the target device by exploiting parsing vulnerabilities.</p>
    <p>CBOR is intended to be less vulnerable to such attacks relative to alternatives
-like JSON and XML.  Still, implementations should be thoroughly tested using
-approaches like <a href="https://en.wikipedia.org/wiki/Fuzzing">fuzz testing</a>.</p>
-   <p>Where possible, Open Screen Protocol implementations (including the content
-rendering components) should use defense-in-depth techniques like <a href="https://en.wikipedia.org/wiki/Sandbox_(computer_security)">sandboxing</a> to prevent vulnerabilities from gaining access to user data or leading to
+like JSON and XML.  Still, agents should be thoroughly tested using approaches
+like <a href="https://en.wikipedia.org/wiki/Fuzzing">fuzz testing</a>.</p>
+   <p>Where possible, Open Screen Protocol agents (including the content rendering
+components) should use defense-in-depth techniques like <a href="https://en.wikipedia.org/wiki/Sandbox_(computer_security)">sandboxing</a> to prevent vulnerabilities from gaining access to user data or leading to
 persistent exploits.</p>
    <h2 class="heading settled" id="appendix-a"><span class="content">Appendix A: Messages</span><a class="self-link" href="#appendix-a"></a></h2>
    <p>The following messages are defined with <a data-link-type="biblio" href="#biblio-cddl">[CDDL]</a>. When

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version a816d78e14132d4d4d2ee44ccaf1b8bc90ac75d5" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="fbfe37e986003f26623c89abb786488b2e73f8ae" name="document-revision">
+  <meta content="f33127b767855f2f47e713afde2ed716c4ed19a3" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1403,7 +1403,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-01-02">2 January 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-01-03">3 January 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1463,7 +1463,6 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li><a href="#active-network-attackers"><span class="secno">8.1.2</span> <span class="content">Active Network Attackers</span></a>
         <li><a href="#denial-of-service"><span class="secno">8.1.3</span> <span class="content">Denial of Service</span></a>
         <li><a href="#same-origin-policy-violations"><span class="secno">8.1.4</span> <span class="content">Same-Origin Policy Violations</span></a>
-        <li><a href="#third-party-tracking"><span class="secno">8.1.5</span> <span class="content">Third Party Tracking</span></a>
        </ol>
       <li>
        <a href="#security-privacy-questions"><span class="secno">8.2</span> <span class="content">Open Screen Protocol Considerations</span></a>
@@ -1985,23 +1984,25 @@ Playback API. <a href="https://github.com/webscreens/openscreenprotocol/issues/1
    <p>The Open Screen Protocol allows two networked user agents to discover each other
 and exchange user and application data.  As such, its security and privacy
 considerations should be closely examined.  We first evaluate the protocol
-itself using the W3C <a data-link-type="biblio" href="#biblio-security-privacy-questionnaire">[SECURITY-PRIVACY-QUESTIONNAIRE]</a>.  We then examine
-whether the security and privacy guidelines recommended by the <a data-link-type="biblio" href="#biblio-presentation-api">[PRESENTATION-API]</a> and the [[REMOTE-PLAYBACK] are met.</p>
+itself using the W3C <a data-link-type="biblio" href="#biblio-security-privacy-questionnaire">Security and Privacy
+Questionnaire</a>.  We then examine whether the security and privacy guidelines
+recommended by the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> and the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> are met.  Finally we discuss recommended
+mitigations that implementations can use to meet these security and privacy
+requirements.</p>
    <h3 class="heading settled" data-level="8.1" id="threat-models"><span class="secno">8.1. </span><span class="content">Threat Models</span><a class="self-link" href="#threat-models"></a></h3>
    <h4 class="heading settled" data-level="8.1.1" id="passive-network-attackers"><span class="secno">8.1.1. </span><span class="content">Passive Network Attackers</span><a class="self-link" href="#passive-network-attackers"></a></h4>
    <p>The Open Screen Protocol should assume that all parties that are connected to
-the same LAN as the user agents, either through a wired connection or through
-WiFi, are able to observe all data flowing between Open Screen controllers and
-receivers.</p>
+the same LAN, either through a wired connection or through WiFi, are able to
+observe all data flowing between Open Screen controllers and receivers.</p>
    <p>These parties will be able collect any data exposed through unencrypted
 messages, such as mDNS records and the QUIC handshake.</p>
    <p>These parties may attempt to learn cryptographic parameters by observing data
 flows on the QUIC connection, or by observing cryptographic timing.</p>
    <h4 class="heading settled" data-level="8.1.2" id="active-network-attackers"><span class="secno">8.1.2. </span><span class="content">Active Network Attackers</span><a class="self-link" href="#active-network-attackers"></a></h4>
-   <p>In addition, all parties with access to the LAN will be able to manipulate data
+   <p>In addition, all parties connected to the LAN will be able to manipulate data
 exchanged between controllers and receivers.  They will be able to inject
-traffic into both parties and attempt to inititate new QUIC connections.  These abilities
-can be used to attempt the following:</p>
+traffic into existing QUIC connections and attempt to inititate new QUIC
+connections.  These abilities can be used to attempt the following:</p>
    <ul>
     <li data-md>
      <p>Impersonate a new receiver or one already trusted by the user, in an attempt
@@ -2013,32 +2014,30 @@ to convince the user to authenticate to it.</p>
 from the application state of the presentation or remote playback.</p>
    </ul>
    <p>One particular attack of concern is misconfigured or compromised routers that
-expose local network devices to the Internet.  This vector of attack has been
-used by remote parties to take control of printers and smart TVs by connecting
-to local network services that should normally be inaccessible from the
-Internet.</p>
+expose local network devices (such as Open Screen Protocol controllers and
+receivers) to the Internet.  This vector of attack has been used by malicious
+parties to take control of printers and smart TVs by connecting to local network
+services that would normally be inaccessible from the Internet.</p>
    <h4 class="heading settled" data-level="8.1.3" id="denial-of-service"><span class="secno">8.1.3. </span><span class="content">Denial of Service</span><a class="self-link" href="#denial-of-service"></a></h4>
-   <p>Parties with access to the LAN may attempt to deny access to receivers by
-controllers, or vice versa.  For example, an active attacker my attempt to start
-a large number of QUIC connections on a receiver in an attempt to block
-legitimate connections or exhaust available resources on the presentation
-display.  They may also multicast spurious DNS-SD records in an attempt to
-exhaust the cache capacity for mDNS listeners.</p>
+   <p>Parties with connected to the LAN may attempt to deny access to Open Screen
+Protocol controllers and receivers.  For example, an attacker my attempt to open
+a large number of QUIC connections to a receiver in an attempt to block
+legitimate connections or exhaust the receiver’s system resources.  They may
+also multicast spurious DNS-SD records in an attempt to exhaust the cache
+capacity for mDNS listeners, or to get listeners to open a large number of bogus
+QUIC connections.</p>
    <h4 class="heading settled" data-level="8.1.4" id="same-origin-policy-violations"><span class="secno">8.1.4. </span><span class="content">Same-Origin Policy Violations</span><a class="self-link" href="#same-origin-policy-violations"></a></h4>
    <p>The Presentation API allows cross-origin communication between controlling pages
 and presentations with the consent of each origin (through their use of the
-API).  This is similar to cross-origin communication via <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage" id="ref-for-dom-worker-postmessage">postMessage</a></code>.  The
-Open Screen Protocol does not convey origin information between controllers and
-receivers.</p>
+API).  This is similar to cross-origin communication via <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage" id="ref-for-dom-window-postmessage">postMessage()</a></code> with a target origin of <code>*</code>.  However, the Presentation API does not convey
+source origin information with each message.  Therefore, the Open Screen
+Protocol does not convey origin information between controllers and receivers.</p>
    <p>The <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-id" id="ref-for-dfn-presentation-id③">presentation ID</a> carries some protection against unrestricted
-cross-origin access, but authentication of the parties connected by a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection②">PresentationConnection</a></code> can be done at the application level.</p>
-   <h4 class="heading settled" data-level="8.1.5" id="third-party-tracking"><span class="secno">8.1.5. </span><span class="content">Third Party Tracking</span><a class="self-link" href="#third-party-tracking"></a></h4>
-   <p>The Open Screen Protocol does not give third party origins additional access to
-presentations or remote playback state.</p>
+cross-origin access; but, rigorous authentication of the parties connected by a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection②">PresentationConnection</a></code> must be done at the application level.</p>
    <h3 class="heading settled" data-level="8.2" id="security-privacy-questions"><span class="secno">8.2. </span><span class="content">Open Screen Protocol Considerations</span><a class="self-link" href="#security-privacy-questions"></a></h3>
    <h4 class="heading settled" data-level="8.2.1" id="personally-identifiable-information"><span class="secno">8.2.1. </span><span class="content">Personally Identifiable Information &amp; High-Value Data</span><a class="self-link" href="#personally-identifiable-information"></a></h4>
-   <p>The following data exchanged by the protocol can be personally identifiable and
-thus is high value data:</p>
+   <p>The following data exchanged by the protocol can be personally identifiable
+and/or high value data:</p>
    <ol>
     <li data-md>
      <p>Presentation URLs and availability results</p>
@@ -2055,7 +2054,7 @@ thus is high value data:</p>
    </ol>
    <p>Presentation display friendly names, model names, and capabilities, while not
 considered personally identifiable, is important to protect to preserve the
-integrity of the discovery process.</p>
+integrity of the discovery and authentication process.</p>
    <p>The following data cannot be reasonably secured and should be considered public
 and untrusted data:</p>
    <ol>
@@ -2068,20 +2067,24 @@ metadata version.</p>
    <h4 class="heading settled" data-level="8.2.2" id="cross-origin-state"><span class="secno">8.2.2. </span><span class="content">Cross Origin State Considerations</span><a class="self-link" href="#cross-origin-state"></a></h4>
    <p>Access to origin state across browsing sessions is possible through the
 Presentation API by reconnecting to a presentation that was started by a
-previous session. This sceanrio is addressed in <a href="https://www.w3.org/TR/presentation-api/#cross-origin-access">Presentation API §cross-origin-access</a>.</p>
-   <p>Presentation display availability and remote playback availability are states
-that may be available cross-origin depending on the user’s network context.
-Exposure of this data to the Web is also discussed in <a href="https://www.w3.org/TR/presentation-api/#personally-identifiable-information">Presentation API §personally-identifiable-information</a> and <a href="https://www.w3.org/TR/remote-playback/#personally-identifiable-information">Remote Playback API §personally-identifiable-information</a>.</p>
+previous session. This scenario is addressed in <a href="https://www.w3.org/TR/presentation-api/#cross-origin-access">Presentation API §cross-origin-access</a>.</p>
+   <p>Presentation display availability and remote playback device availability are
+states that are available cross-origin depending on the user’s network
+context.  Exposure of this data to the Web is also discussed in <a href="https://www.w3.org/TR/presentation-api/#personally-identifiable-information">Presentation API §personally-identifiable-information</a> and <a href="https://www.w3.org/TR/remote-playback/#personally-identifiable-information">Remote Playback API §personally-identifiable-information</a>.</p>
    <h4 class="heading settled" data-level="8.2.3" id="origin-access-devices"><span class="secno">8.2.3. </span><span class="content">Origin Access to Other Devices</span><a class="self-link" href="#origin-access-devices"></a></h4>
-   <p>By design, the Open Screen Protocol allows access to presentation displays from
-the Web.  By implementing the protocol, these devices are knowingly making
-themselves available to the Web and should be designed accordingly.</p>
-   <p>Below, we discuss mitigation steps to prevent malicious use of presentation
-displays.</p>
+   <p>By design, the Open Screen Protocol allows access to presentation displays and
+remote playback devices from the Web.  By implementing the protocol, these
+devices are knowingly making themselves available to the Web and should be
+designed accordingly.</p>
+   <p>Below, we discuss mitigation steps to prevent malicious use of these devices.</p>
    <h4 class="heading settled" data-level="8.2.4" id="incognito-mode"><span class="secno">8.2.4. </span><span class="content">Incognito Mode</span><a class="self-link" href="#incognito-mode"></a></h4>
    <p>The Open Screen Protocol does not distinguish between the user agent’s normal
 browsing and incognito modes, and should operate identically regardless of which
-mode is using it.</p>
+mode is in use.</p>
+   <p>It’s recommended that controllers use separate authentication contexts and QUIC
+connections for normal and incognito profiles from the same user agent instance.
+This prevents Open Screen receivers from correlating activity between a user’s
+normal profile and their incognito profile.</p>
    <h4 class="heading settled" data-level="8.2.5" id="persistent-state"><span class="secno">8.2.5. </span><span class="content">Persistent State</span><a class="self-link" href="#persistent-state"></a></h4>
    <p>An implementation of the Open Screen Protocol is likely to persist the identity
 of controllers and receivers that have successfully completed <a href="#authentication">§6 Authentication</a>.  This may include the public key fingerprints, metadata
@@ -2090,7 +2093,8 @@ versions, and metadata for those parties.</p>
 UI of the user agent during the display selection or display authentication
 process.  It can be an implementation choice whether the user agent clears or
 retains this data when the user clears browsing data.</p>
-   <p>TODO: File an issue to discuss</p>
+   <p class="issue" id="issue-7d9298b1"><a class="self-link" href="#issue-7d9298b1"></a> [Privacy] Fate of metadata / authentication history when clearing
+browsing data <a href="https://github.com/webscreens/openscreenprotocol/issues/132">&lt;https://github.com/webscreens/openscreenprotocol/issues/132></a></p>
    <h4 class="heading settled" data-level="8.2.6" id="other-considerations"><span class="secno">8.2.6. </span><span class="content">Other Considerations</span><a class="self-link" href="#other-considerations"></a></h4>
    <p>The Open Screen Protocol does not grant to the Web additional access to the
 following:</p>
@@ -2109,9 +2113,8 @@ following:</p>
      <p>Security characteristics of the user agent</p>
    </ul>
    <h3 class="heading settled" data-level="8.3" id="presentation-api-considerations"><span class="secno">8.3. </span><span class="content">Presentation API Considerations</span><a class="self-link" href="#presentation-api-considerations"></a></h3>
-   <p>[[PRESENTATION-API#security-and-privacy-considerations][Presentation API
-Security and Privacy Considerations]] place these requirements on the Open
-Screen Protocol:</p>
+   <p><a href="https://www.w3.org/TR/presentation-api/#security-and-privacy-considerations">Presentation API §security-and-privacy-considerations</a> place these
+requirements on the Open Screen Protocol:</p>
    <ol>
     <li data-md>
      <p>Presentation URLs and presentation IDs should remain private among the
@@ -2135,9 +2138,9 @@ connections.</p>
  receivers can track the number of active connections.</p>
    </ol>
    <h3 class="heading settled" data-level="8.4" id="remote-playback-considerations"><span class="secno">8.4. </span><span class="content">Remote Playback API Considerations</span><a class="self-link" href="#remote-playback-considerations"></a></h3>
-   <p>The [[REMOTE-PLAYBACK#security-and-privacy-considerations][Remote Playback API
-Security and Privacy Considerations]] also state that messaging between local
-and remote playback devices should also be authenticated and confidential.</p>
+   <p>The <a href="https://www.w3.org/TR/remote-playback/#security-and-privacy-considerations">Remote Playback API §security-and-privacy-considerations</a> also state that
+messaging between local and remote playback devices should also be authenticated
+and confidential.</p>
    <p>This consideration is handled by requiring mutual authentication and a
 TLS-secured QUIC connection before any remote playback related messages are
 exchanged.</p>
@@ -2149,14 +2152,15 @@ this is data minimization, by only exposing opaque public key fingerprints
 before user-mediated authentication takes place.</p>
    <p>Passive attackers may also attempt timing attacks to learn cryptographic the
 cryptographic parameters of the TLS 1.3 QUIC connection.</p>
-   <p>TODO: Investigate mitigations for this.</p>
+   <p class="issue" id="issue-5107ff88"><a class="self-link" href="#issue-5107ff88"></a> [Security] Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a></p>
    <h4 class="heading settled" data-level="8.5.2" id="local-active-mitigations"><span class="secno">8.5.2. </span><span class="content">Local active network attackers</span><a class="self-link" href="#local-active-mitigations"></a></h4>
    <p>Local active attackers may attempt to impersonate a presentation display the
 user would normally trust.  The <a href="#authentication">§6 Authentication</a> step of the Open Screen
 Protocol prevents a man-in-the-middle from impersonating a controller or
 receiver, without knowledge of a shared secret.  However, it is possible for an
 attacker to impersonate an existing, trusted display or a newly discovered
-display that is not yet authenticated by convincing the user to authenticate it.</p>
+display that is not yet authenticated and try to convince the user to
+authenticate it.</p>
    <p>This can be addressed through a combination of techniques.  The first is flagging:</p>
    <ul>
     <li data-md>
@@ -2187,14 +2191,14 @@ display - to prevent the user from blindly clicking through this step.</p>
    <p>The active attacker may also attempt to disrupt data exchanged over the QUIC
 connection by injecting or modifying traffic.  These attacks should be mitigated
 by a correct implementation of TLS 1.3.</p>
-   <p>TODO: Protect against TLS replay, esp. if we enable early data.</p>
+   <p class="issue" id="issue-5107ff88①"><a class="self-link" href="#issue-5107ff88①"></a> [Security] Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a></p>
    <h4 class="heading settled" data-level="8.5.3" id="remote-active-mitigations"><span class="secno">8.5.3. </span><span class="content">Remote active network attackers</span><a class="self-link" href="#remote-active-mitigations"></a></h4>
    <p>Unfortunately, we cannot rely on network devices to fully protect Open Screen
 controllers and receivers from traffic from the broader Internet.  Open Screen
 Protocol implementations that are only intended to work on the LAN should filter
 packets from non-local IP addresses.  Implementations can also use the ARP cache
 to detect attempts to spoof local network IP addresses.</p>
-   <p>TODO: Fill in more details here.</p>
+   <p class="issue" id="issue-1353180f"><a class="self-link" href="#issue-1353180f"></a> [Security] Mitigations for remote network attackers <a href="https://github.com/webscreens/openscreenprotocol/issues/131">&lt;https://github.com/webscreens/openscreenprotocol/issues/131></a></p>
    <h4 class="heading settled" data-level="8.5.4" id="denial-of-service-mitigations"><span class="secno">8.5.4. </span><span class="content">Denial of service</span><a class="self-link" href="#denial-of-service-mitigations"></a></h4>
    <p>It will be difficult to completely prevent denial service of attacks that
 originate on the user’s local area network.  Open Screen Protocol
@@ -2209,8 +2213,7 @@ vulnerabilities.</p>
 like JSON and XML.  Still, implementations should be thoroughly tested using
 approaches like <a href="https://en.wikipedia.org/wiki/Fuzzing">fuzz testing</a>.</p>
    <p>Where possible, Open Screen Protocol implementations (including the content
-rendering components) should use defense-in-depth techniques like <a href="https://en.wikipedia.org/wiki/Sandbox_(computer_security">sandboxing</a>).
-to prevent vulnerabilities from gaining access to user data or leading to
+rendering components) should use defense-in-depth techniques like <a href="https://en.wikipedia.org/wiki/Sandbox_(computer_security)">sandboxing</a> to prevent vulnerabilities from gaining access to user data or leading to
 persistent exploits.</p>
    <h2 class="heading settled" id="appendix-a"><span class="content">Appendix A: Messages</span><a class="self-link" href="#appendix-a"></a></h2>
    <p>The following messages are defined with <a data-link-type="biblio" href="#biblio-cddl">[CDDL]</a>. When
@@ -2551,10 +2554,10 @@ result = (
 })();
 </script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <aside class="dfn-panel" data-for="term-for-dom-worker-postmessage">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage">https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-dom-window-postmessage">
+   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-worker-postmessage">8.1.4. Same-Origin Policy Violations</a>
+    <li><a href="#ref-for-dom-window-postmessage">8.1.4. Same-Origin Policy Violations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-media-element">
@@ -2647,7 +2650,7 @@ result = (
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-dom-worker-postmessage" style="color:initial">postMessage()</span>
+     <li><span class="dfn-paneled" id="term-for-dom-window-postmessage" style="color:initial">postMessage(message, targetOrigin, transfer)</span>
     </ul>
    <li>
     <a data-link-type="biblio">[html51]</a> defines the following terms:
@@ -2710,6 +2713,11 @@ result = (
    <div class="issue"> Incorporate material from the <a href="j-pake.md">J-PAKE</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/102">&lt;https://github.com/webscreens/openscreenprotocol/issues/102></a><a href="#issue-7d8c18ff"> ↵ </a></div>
    <div class="issue"> Propose control protocol for Remote
 Playback API. <a href="https://github.com/webscreens/openscreenprotocol/issues/12">&lt;https://github.com/webscreens/openscreenprotocol/issues/12></a><a href="#issue-eaed3698"> ↵ </a></div>
+   <div class="issue"> [Privacy] Fate of metadata / authentication history when clearing
+browsing data <a href="https://github.com/webscreens/openscreenprotocol/issues/132">&lt;https://github.com/webscreens/openscreenprotocol/issues/132></a><a href="#issue-7d9298b1"> ↵ </a></div>
+   <div class="issue"> [Security] Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a><a href="#issue-5107ff88"> ↵ </a></div>
+   <div class="issue"> [Security] Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a><a href="#issue-5107ff88①"> ↵ </a></div>
+   <div class="issue"> [Security] Mitigations for remote network attackers <a href="https://github.com/webscreens/openscreenprotocol/issues/131">&lt;https://github.com/webscreens/openscreenprotocol/issues/131></a><a href="#issue-1353180f"> ↵ </a></div>
   </div>
 <script>/* script-dfn-panel */
 

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,11 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version a816d78e14132d4d4d2ee44ccaf1b8bc90ac75d5" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
+<<<<<<< HEAD
   <meta content="f33127b767855f2f47e713afde2ed716c4ed19a3" name="document-revision">
+=======
+  <meta content="46293b6c6367bb91201b5df913d784680d4d2f95" name="document-revision">
+>>>>>>> Fix index.html
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1403,7 +1407,11 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
+<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-01-03">3 January 2019</time></span></h2>
+=======
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-01-14">14 January 2019</time></span></h2>
+>>>>>>> Fix index.html
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1774,7 +1782,100 @@ those.  A request and a response includes a request ID which is an unsigned
 integer chosen by the requester.  Responses must include the request ID of the
 request they are associated with.</p>
    <h2 class="heading settled" data-level="6" id="authentication"><span class="secno">6. </span><span class="content">Authentication</span><a class="self-link" href="#authentication"></a></h2>
-   <p class="issue" id="issue-7d8c18ff"><a class="self-link" href="#issue-7d8c18ff"></a> Incorporate material from the <a href="j-pake.md">J-PAKE</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/102">&lt;https://github.com/webscreens/openscreenprotocol/issues/102></a></p>
+   <p>In order for one agent (the challenger) to authenticate another (the responder),
+the challenger may send an authentication-request message and expect an
+authentication-response message to be sent back from the responder.  To
+mutually authenticate, this mechanism is used twice, once by each side acting as
+the challenger.  This mechanism assumes the agents share a low-entropy secret,
+such as a number or a short password that could be entered by a user on a
+keyboard or TV remote control.</p>
+   <p>For all messages and objects defined in this section, see Appendix A for the full
+CDDL definitions.</p>
+   <p>The challenger sends an authentication-request message with the following values:</p>
+   <ul>
+    <li data-md>
+     <p>mechanism: The authentication mechanism being used.  This standard only
+defines the mechanism hkdf-of-scrypt-of-psk but this field gives a place for
+other mechanisms to be specified.</p>
+    <li data-md>
+     <p>salt: 32 random bytes.  This salt is used in HKDF, so see
+https://tools.ietf.org/html/rfc5869#section-3.1 for more details on how this
+value should be generated.</p>
+    <li data-md>
+     <p>cost: log base 2 of the cost parameter (N) for scrypt defined in <a href="https://tools.ietf.org/html/rfc7914#section-2">RFC
+7914 section 2</a>.  It must be
+greater than or equal to 14 (to avoid being too weak) and less than or equal
+to 128 (the limit defined by scrypt).  A value of 15 is recommended (an
+scrypt N of 2^15 or 32768).</p>
+   </ul>
+   <p>The responder replies with an authentication-response message with the following values:</p>
+   <ul>
+    <li data-md>
+     <p>result:  If the responder was able to calculate proof of possession of the
+shared secret, and if it failed, why it failed.</p>
+    <li data-md>
+     <p>proof: The result of running the authentication mechanism.  The steps for
+hkdf-of-scrypt-of-psk are described below.</p>
+   </ul>
+   <p>The challenger verifies the proof and sends the responder an
+authentication-result message with the following values:</p>
+   <ul>
+    <li data-md>
+     <p>result:  If the challenger was able to authenticate the responder or not,
+and if not, why not.</p>
+   </ul>
+   <p>The challenger must limit the time the responder has to send a response to 60
+seconds (to avoid the possibility of brute-force attacks.)</p>
+   <p>For hkdf-of-scrypt-of-psk, the proof is calculated using the following steps:</p>
+   <ol>
+    <li data-md>
+     <p>Let secret be the pre-shared secret.</p>
+    <li data-md>
+     <p>Let N be 2 to the power of of the cost from the authentication-request
+ message.</p>
+    <li data-md>
+     <p>Let r be 8.</p>
+    <li data-md>
+     <p>Let p be 1.</p>
+    <li data-md>
+     <p>Let keyLength be 32.</p>
+    <li data-md>
+     <p>Let scryptResult be the result of running <a href="https://tools.ietf.org/html/rfc7914">scrypt</a> on secret with cost parameter N,
+ block size r, parallelization parameter p, and derived key length of
+ keyLength.</p>
+    <li data-md>
+     <p>Let hashFunction be sha-256.</p>
+    <li data-md>
+     <p>Let salt be the salt from the authentication-request message.</p>
+    <li data-md>
+     <p>Let info be a CBOR-serialized certificate-fingerprint-pair object (CDDL
+ defined in Appendix A) with the following values:</p>
+   </ol>
+   <ul>
+    <li data-md>
+     <p>challenger-fingerprint: The result of running sha-256 on the
+Distinguished Encoding Rules (DER) form (see
+https://tools.ietf.org/html/rfc8122#section-5) of the certificate used by
+the challenger in the QUIC crypto handshake during connection establishment.</p>
+    <li data-md>
+     <p>responder-fingerprint: The result of running sha-256 on the
+Distinguished Encoding Rules (DER) form (see
+https://tools.ietf.org/html/rfc8122#section-5) of the certificate used by
+the responder in the QUIC crypto handshake during connection establishment.</p>
+   </ul>
+   <ol start="9">
+    <li data-md>
+     <p>Let proof be the result of running <a href="https://tools.ietf.org/html/rfc5869">\HKDF</a> on scryptResult with 
+ both the extract and expand steps, hash function hashFunction,
+ application-specific info, and output key length keyLength.</p>
+   </ol>
+   <p>To verify that the responder’s proof is correct, the challenger makes the same
+calculation of the proof and compares the result. If the results are the same,
+the challenger considers the responder authenticated, and considers it
+unauthenticated otherwise.</p>
+   <p class="note" role="note"><span>Note:</span> the values of 32 above (for salt length, keyLength) are based on the
+output size of sha-256.  If a different hash mechanism is used in the future,
+these values should be updated as well.</p>
    <h2 class="heading settled" data-level="7" id="control-protocols"><span class="secno">7. </span><span class="content">Control Protocols</span><a class="self-link" href="#control-protocols"></a></h2>
    <h3 class="heading settled" data-level="7.1" id="presentation-protocol"><span class="secno">7.1. </span><span class="content">Presentation Protocol</span><a class="self-link" href="#presentation-protocol"></a></h3>
    <p>This section defines the use of the Open Screen Protocol for starting,
@@ -2267,6 +2368,53 @@ response = (
 
 request-id = uint
 
+; type key 1001 
+authentication-request = {
+  request
+  1: authentication-mechanism ; mechanism
+  2: bytes ; salt
+  3: uint ; cost
+}
+
+; type key 1002 
+authentication-response = {
+  response
+  1: authentication-response-result ; result
+  2: bytes ; proof
+}
+
+certificate-fingerprint-pair = [
+  challenger-fingerprint: bytes
+  responder-fingerprint: bytes
+]
+
+; type key 1003
+authentication-result = {
+  1: authentication-result-result ; result
+}
+
+
+authentication-mechanism = &amp;(
+  hkdf-of-scrypt-of-psk: 1
+)
+
+authentication-response-result = &amp;(
+  ok: 0
+  unknown-error: 1
+  mechanism-unknown: 2
+  salt-too-small: 3
+  cost-too-low: 4
+  cost-too-high: 5
+  secret-unknown: 6
+  calculation-took-too-long: 7
+)
+
+authentication-result-result = &amp;(
+  authenticated: 0
+  unknown-error: 1
+  proof-invalid: 2
+)
+
 ; type key 14
 presentation-url-availability-request = {
   request
@@ -2710,7 +2858,6 @@ result = (
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
    <div class="issue"> Requirements for Remote Playback API <a href="https://github.com/webscreens/openscreenprotocol/issues/3">&lt;https://github.com/webscreens/openscreenprotocol/issues/3></a><a href="#issue-a1f35a95"> ↵ </a></div>
-   <div class="issue"> Incorporate material from the <a href="j-pake.md">J-PAKE</a> document. <a href="https://github.com/webscreens/openscreenprotocol/issues/102">&lt;https://github.com/webscreens/openscreenprotocol/issues/102></a><a href="#issue-7d8c18ff"> ↵ </a></div>
    <div class="issue"> Propose control protocol for Remote
 Playback API. <a href="https://github.com/webscreens/openscreenprotocol/issues/12">&lt;https://github.com/webscreens/openscreenprotocol/issues/12></a><a href="#issue-eaed3698"> ↵ </a></div>
    <div class="issue"> [Privacy] Fate of metadata / authentication history when clearing

--- a/index.html
+++ b/index.html
@@ -1403,7 +1403,11 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
+<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-03-05">5 March 2019</time></span></h2>
+=======
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-03-22">22 March 2019</time></span></h2>
+>>>>>>> Address more comments
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2177,10 +2181,10 @@ designed accordingly.</p>
    <p>The Open Screen Protocol does not distinguish between the user agent’s normal
 browsing and incognito modes, and agents that follow the specification
 behave identically regardless of which mode is in use.</p>
-   <p>It’s recommended that controllers use separate authentication contexts and QUIC
+   <p>It’s recommended that user agents use separate authentication contexts and QUIC
 connections for normal and incognito profiles from the same user agent instance.
-This prevents Open Screen receivers from correlating activity among a user’s
-profiles (both normal and incognito).</p>
+This prevents Open Screen agents from correlating activity among profiles
+belonging to the same user (both normal and incognito).</p>
    <h4 class="heading settled" data-level="8.2.5" id="persistent-state"><span class="secno">8.2.5. </span><span class="content">Persistent State</span><a class="self-link" href="#persistent-state"></a></h4>
    <p>An agent is likely to persist the identity of agents that have successfully
 completed <a href="#authentication">§6 Authentication</a>.  This may include the public key fingerprints,
@@ -2217,10 +2221,11 @@ requirements on the Open Screen Protocol:</p>
 parties that are allowed to connect to a presentation, per the
 cross-origin access guidelines.</p>
     <li data-md>
-     <p>Controllers and receivers should be notified when multiple connections have
-been made to a presentation, per the user interface guidelines.</p>
+     <p>Controllers and receivers should be notified when connections representing
+multiple user agent profiles have been made to a presentation, per the user
+interface guidelines.</p>
     <li data-md>
-     <p>Messaging between presentations and controllers should be authenticated and
+     <p>Messaging between controllers and receivers should be authenticated and
 confidential, per the guidelines for messaging between presentation
 connections.</p>
    </ol>
@@ -2246,7 +2251,7 @@ exchanged.</p>
 device capabilties using the Open Screen Protocol.  The main strategy to address
 this is data minimization, by only exposing opaque public key fingerprints
 before user-mediated authentication takes place.</p>
-   <p>Passive attackers may also attempt timing attacks to learn cryptographic the
+   <p>Passive attackers may also attempt timing attacks to learn the
 cryptographic parameters of the TLS 1.3 QUIC connection.</p>
    <p class="issue" id="issue-5107ff88"><a class="self-link" href="#issue-5107ff88"></a> [Security] Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a></p>
    <h4 class="heading settled" data-level="8.5.2" id="local-active-mitigations"><span class="secno">8.5.2. </span><span class="content">Local active network attackers</span><a class="self-link" href="#local-active-mitigations"></a></h4>
@@ -2259,8 +2264,11 @@ not yet authenticated and try to convince the user to authenticate it.</p>
    <p>This can be addressed through a combination of techniques.  The first is flagging:</p>
    <ul>
     <li data-md>
-     <p>Flag advertised displays whose friendly name, public key fingerprint, or
-IP:port collide with an already trusted display.</p>
+     <p>Flag an advertised display whose public key fingerprint collides with that
+from an already-trusted display that is concurrently being advertised.</p>
+    <li data-md>
+     <p>Flag an advertised display whose friendly name differs from the one previously
+advertised under a public key fingerprint.</p>
     <li data-md>
      <p>Flag already-trusted displays whose metadata has changed.</p>
     <li data-md>

--- a/index.html
+++ b/index.html
@@ -1214,6 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version a816d78e14132d4d4d2ee44ccaf1b8bc90ac75d5" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
+  <meta content="71babf14faaf631374051c949c544c55d100162c" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1402,6 +1403,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-01-15">15 January 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1463,7 +1465,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li><a href="#same-origin-policy-violations"><span class="secno">8.1.4</span> <span class="content">Same-Origin Policy Violations</span></a>
        </ol>
       <li>
-       <a href="#security-privacy-questions"><span class="secno">8.2</span> <span class="content">Open Screen Protocol Considerations</span></a>
+       <a href="#security-privacy-questions"><span class="secno">8.2</span> <span class="content">Open Screen Protocol Security and Privacy Considerations</span></a>
        <ol class="toc">
         <li><a href="#personally-identifiable-information"><span class="secno">8.2.1</span> <span class="content">Personally Identifiable Information &amp; High-Value Data</span></a>
         <li><a href="#cross-origin-state"><span class="secno">8.2.2</span> <span class="content">Cross Origin State Considerations</span></a>
@@ -2125,7 +2127,7 @@ API does not convey source origin information with each message.  Therefore, the
 Open Screen Protocol does not convey origin information between its agents.</p>
    <p>The <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-id" id="ref-for-dfn-presentation-id③">presentation ID</a> carries some protection against unrestricted
 cross-origin access; but, rigorous authentication of the parties connected by a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection②">PresentationConnection</a></code> must be done at the application level.</p>
-   <h3 class="heading settled" data-level="8.2" id="security-privacy-questions"><span class="secno">8.2. </span><span class="content">Open Screen Protocol Considerations</span><a class="self-link" href="#security-privacy-questions"></a></h3>
+   <h3 class="heading settled" data-level="8.2" id="security-privacy-questions"><span class="secno">8.2. </span><span class="content">Open Screen Protocol Security and Privacy Considerations</span><a class="self-link" href="#security-privacy-questions"></a></h3>
    <h4 class="heading settled" data-level="8.2.1" id="personally-identifiable-information"><span class="secno">8.2.1. </span><span class="content">Personally Identifiable Information &amp; High-Value Data</span><a class="self-link" href="#personally-identifiable-information"></a></h4>
    <p>The following data exchanged by the protocol can be personally identifiable
 and/or high value data:</p>
@@ -2215,7 +2217,7 @@ requirements on the Open Screen Protocol:</p>
 parties that are allowed to connect to a presentation, per the
 cross-origin access guidelines.</p>
     <li data-md>
-     <p>Controllers and recievers should be notified when multiple connections have
+     <p>Controllers and receivers should be notified when multiple connections have
 been made to a presentation, per the user interface guidelines.</p>
     <li data-md>
      <p>Messaging between presentations and controllers should be authenticated and
@@ -2272,12 +2274,12 @@ authentication:</p>
     <li data-md>
      <p>Rotate the shared secret to prevent brute force attacks.</p>
     <li data-md>
-     <p>Use an increasing backoff to repond to authentication challenges, also to
+     <p>Use an increasing backoff to respond to authentication challenges, also to
 prevent brute force attacks.</p>
     <li data-md>
      <p>Use a cryptographically sound source of entropy to generate the shared secret.</p>
     <li data-md>
-     <p>Require the end user to manually type the shared secret - shown only the
+     <p>Require the end user to manually type the shared secret - shown only on the
 display - to prevent the user from blindly clicking through this step.</p>
    </ul>
    <p>The active attacker may also attempt to disrupt data exchanged over the QUIC


### PR DESCRIPTION
Addresses Issue #13: Propose security mechanisms for the OSP

This is a draft version of the Security and Privacy section of the Open Screen Protocol spec, following the W3C's Security and Privacy Questionnaire [1].  It addresses the following:

* Threats
* Considerations specific to the OSP
* Considerations from the Security and Privacy sections of the Presentation API and Remote Playback API
* Some possible mitigations, with issues filed to investigate some specific areas further

Would appreciate wide review.  In particular, if there are topics from previous discussions missing, can add them here or in a followup PR.

[1] https://www.w3.org/TR/security-privacy-questionnaire/#questions