### PR TITLE
Add capabilities 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -297,38 +297,35 @@ mechanism for metadata discovery.
 Transport and metadata discovery with QUIC {#transport}
 =======================================================
 
-If a listening agent ("listener") wants to connect to an advertising agent
-("advertiser"), or to learn further metadata about it, it initiates a [[QUIC]]
-connection to the IP and port from the SRV record.  Prior to authentication,
-a message may be exchanged (such as further metadata), but such info should be
-treated as unverified (such as indicating to a user that a display name of an
-unauthenticated agent is unverified). Note that both listeners and advertisers
-may request information about each other (performing as a "requester" to
-query a "requestee").
+If an agent wants to connect to or learn further metadata about another agent,
+it initiates a [[QUIC]] connection to the IP and port from the SRV record.
+Prior to authentication, a message may be exchanged (such as further metadata),
+but such info should be treated as unverified (such as indicating to a user that
+a display name of an unauthenticated agent is unverified).
 
-To learn further metadata, devices may send an agent-info-request
+To learn further metadata, an agent may send an agent-info-request
 message (see [[#appendix-a]]) and receive back an agent-info-response message.
-Note that both the listener and advertiser may send this request to learn about
-the capabilities of the other device.
+Any agent may send this request to learn about the capabilities of
+another device.
 
-The messages may contain the following properties:
+The agent-info-response messages contain the following properties:
 
 : display-name (required)
-:: The display name of the requestee, intended to be displayed to a user by the
+:: The display name of the agent, intended to be displayed to a user by the
      requester. The requester should indicate through the UI if the device
      is not authenticated or if the display name changes.
 
 : model-name (optional)
-:: If the requestee is a hardware device, the model name of
+:: If the agent is a hardware device, the model name of
     the device.  This is used mainly for debugging purposes, but may be
     displayed to the user of the requesting agent.
 
 : supports-audio (optional)
-:: The requestee has to indicate that it supports audio streaming. If false
+:: The agent has to indicate that it supports audio streaming. If false
     or not included, it is assumed audio streaming is not supported.
 
 : supports-video (optional)
-:: The requestee has to indicate that it supports video streaming. If false
+:: The agent has to indicate that it supports video streaming. If false
     or not included, it is assumed video streaming is not supported.
 
 

--- a/index.bs
+++ b/index.bs
@@ -308,11 +308,11 @@ message (see [[#appendix-a]]) and receive back an agent-info-response message.
 Any agent may send this request to learn about the capabilities of
 another device.
 
-The agent-info-response messages contain the following properties:
+The agent-info-response message contains the following properties:
 
 : display-name (required)
 :: The display name of the agent, intended to be displayed to a user by the
-     requester. The requester should indicate through the UI if the device
+     requester. The requester should indicate through the UI if the responder
      is not authenticated or if the display name changes.
 
 : model-name (optional)
@@ -320,13 +320,13 @@ The agent-info-response messages contain the following properties:
     the device.  This is used mainly for debugging purposes, but may be
     displayed to the user of the requesting agent.
 
-: supports-audio (optional)
-:: The agent has to indicate that it supports audio streaming. If false
-    or not included, it is assumed audio streaming is not supported.
+: receives-audio (optional)
+:: The agent has to indicate that it supports audio. If false
+    or not included, it is assumed audio content is not supported.
 
-: supports-video (optional)
-:: The agent has to indicate that it supports video streaming. If false
-    or not included, it is assumed video streaming is not supported.
+: receives-video (optional)
+:: The agent has to indicate that it supports video . If false
+    or not included, it is assumed video content is not supported.
 
 
 Listening agents act as QUIC clients.  Advertising agents act as QUIC servers.
@@ -349,7 +349,7 @@ If a client agent wishes to send messages to a server agent, the client
 agent can connect to the server agent "on demand"; it does not need to
 keep the connection alive.
 
-The agent-info-response message and agent-status-response
+The agent-info-response and agent-status-response
 messages may be extended to include additional information not defined
 in this spec.  If done ad-hoc by applications and not in future specs,
 keys should be chosen to avoid collision, such as by choosing large

--- a/index.bs
+++ b/index.bs
@@ -151,7 +151,7 @@ Presentation API Requirements {#requirements-presentation-api}
     {{PresentationConnection}} to an existing presentation on the
     receiver, given its [=presentation request URL=] and [=presentation ID=].
 
-6.  It must be possible to to close a {{PresentationConnection}} between a
+6.  It must be possible to close a {{PresentationConnection}} between a
     controller and a presentation, and signal both parties with the
     reason why the connection was closed.
 
@@ -297,32 +297,85 @@ mechanism for metadata discovery.
 Transport and metadata discovery with QUIC {#transport}
 =======================================================
 
-If a listening agent wants to connect to an advertising agent, or to
-learn further metadata about it, it initiates a [[QUIC]] connection to
-the IP and port from the SRV record.  Prior to authentication, a message may be
-exchanged (such as further metadata), but such info should be treated as
-unverified (such as indicating to a user that a display name of an
+If a listening agent ("listener") wants to connect to an advertising agent
+("advertiser"), or to learn further metadata about it, it initiates a [[QUIC]]
+connection to the IP and port from the SRV record.  Prior to authentication,
+a message may be exchanged (such as further metadata), but such info should be
+treated as unverified (such as indicating to a user that a display name of an
 unauthenticated agent is unverified).
 
-To learn further metadata, an agent may send an agent-info-request
-message (see [[#appendix-a]]) and receive back an agent-info-response message.  The
-messages may contain the following information with the following meaning:
+To learn further metadata, the listener may send an agent-info-request
+message (see [[#appendix-a]]) and receive back an agent-info-response message.
+The messages may contain the following properties:
 
 : display-name (required)
-:: The display name of the responding agent intended
-    to be displayed to a user by the requesting agent.  If the responding agent
-    is not yet authenticated, the requesting agent should make UI affordance for
-    indicating to the user that the display name is not yet verified.  If the
-    responding agent changes its display name, the requesting agent should
-    make UI affordance for indicating to the user that the display name has
-    changed.
+:: The display name of the advertiser, intended to be displayed to a user by the
+     listener. The listener should indicate through the UI if the advertiser
+     is not authenticated or if the display name changes.
 
 : model-name (optional)
-:: If the agent is a hardware device, the model name of
+:: If the advertiser is a hardware device, the model name of
     the device.  This is used mainly for debugging purposes, but may be
     displayed to the user of the requesting agent.
 
-<!-- TODO: Add device type and/or capabilities -->
+: audio-only (optional)
+:: Generally speaking, advertisers are assumed to support streaming both
+    audio and video. If a advertiser wishes to indicate that they only support audio
+    stream, they can pass this property as true. In that case, the listener
+    should indicate through the UI that the advertiser is audio only.
+
+If the advertiser is already authenticated, the listener has the ability to
+request additional information by sending an streaming-capabilities-request
+message, and receive back a streaming-capabilities-response message with the
+following properties:
+
+: max-pixel-fill-rate (required)
+:: The advertiser shall reply with the supported pixel fill rate in megapixels per
+    second. Requesting agents can use this information to make better-educated
+    decisions about what resolution and frame rates to stream content at.
+
+: supported-codecs (required)
+:: The advertiser must indicate to the listener what codecs it understands for
+    remote playback.
+
+: min-resolution (optional)
+:: The advertiser may indicate what it considers its minimum resolution to be, for
+    setting a minimum boundary on content quality.
+
+: max-resolution (optional)
+:: The advertiser may indicate the maximum resolution and frame rate. Note that
+    this may not be the ideal, depending on the max-pixel-fill-rate.
+
+: max-audio-channels (optional)
+:: The advertiser may indicate the maximum number of audio channels in abilities
+    standard audio setup, e.g. 2 for stereo, 5 or 7 for a surround setup.
+
+: audio-bit-rate-limits (optional)
+:: The advertiser may indicate the practical audio bit rate limits, including the
+    minimum and maximum bit rates, and the maximum latency. Physical hardware
+    requirements, such as maximum decoder throughput or maximum audio buffer
+    size inform these values.
+
+: video-bit-rate-limits (optional)
+:: The advertiser may indicate the practical audio bit rate limits, including the
+    minimum and maximum bit rates, and the maximum latency. Physical hardware
+    requirements, such as maximum decoder throughput or maximum video buffer
+    size inform these values.
+
+: aspect-ratio (optional)
+:: The advertiser may indicate what its ideal aspect ratio is, e.g. a 16:10
+    display could return this value as 1.6 to indicate its preferred content
+    scaling.
+
+: color-profiles (optional)
+:: The advertiser may indicate what color profiles are understood, such as
+    sRGB v4. The listener may use these values to determine how to encode
+    video.
+
+: supports-scaling (optional)
+:: If omitted, this value is assumed to be false. Setting to "True" indicates
+    that the advertiser can scale content that is of an unsupported resolution or
+    non-ideal aspect ratio. If false, the listener must do the scaling.
 
 Listening agents act as QUIC clients.  Advertising agents act as QUIC servers.
 
@@ -339,7 +392,6 @@ frames should not be used.  An idle_timeout transport parameter of 25 seconds is
 recommended.  The agent should behave as though a timer less than the
 idle_timeout were reset every time a message is sent on a QUIC stream.  If the
 timer expires, a agent-status-request message should be sent.
-
 
 If a client agent wishes to send messages to a server agent, the client
 agent can connect to the server agent "on demand"; it does not need to

--- a/index.bs
+++ b/index.bs
@@ -302,41 +302,44 @@ If a listening agent ("listener") wants to connect to an advertising agent
 connection to the IP and port from the SRV record.  Prior to authentication,
 a message may be exchanged (such as further metadata), but such info should be
 treated as unverified (such as indicating to a user that a display name of an
-unauthenticated agent is unverified).
+unauthenticated agent is unverified). Note that both listeners and advertisers
+may request information about each other (performing as a "requester" to
+query a "requestee").
 
-To learn further metadata, the listener may send an agent-info-request
+To learn further metadata, devices may send an agent-info-request
 message (see [[#appendix-a]]) and receive back an agent-info-response message.
+Note that both the listener and advertiser may send this request to learn about
+the capabilities of the other device.
+
 The messages may contain the following properties:
 
 : display-name (required)
-:: The display name of the advertiser, intended to be displayed to a user by the
-     listener. The listener should indicate through the UI if the advertiser
+:: The display name of the requestee, intended to be displayed to a user by the
+     requester. The requester should indicate through the UI if the device
      is not authenticated or if the display name changes.
 
 : model-name (optional)
-:: If the advertiser is a hardware device, the model name of
+:: If the requestee is a hardware device, the model name of
     the device.  This is used mainly for debugging purposes, but may be
     displayed to the user of the requesting agent.
 
-: audio-only (optional)
-:: Generally speaking, advertisers are assumed to support streaming both
-    audio and video. If a advertiser wishes to indicate that they only support audio
-    stream, they can pass this property as true. In that case, the listener
-    should indicate through the UI that the advertiser is audio only.
+: supports-audio (optional)
+:: The requestee has to indicate that it supports audio streaming. If false
+    or not included, it is assumed audio streaming is not supported.
+
+: supports-video (optional)
+:: The requestee has to indicate that it supports video streaming. If false
+    or not included, it is assumed video streaming is not supported.
 
 If the advertiser is already authenticated, the listener has the ability to
 request additional information by sending an streaming-capabilities-request
 message, and receive back a streaming-capabilities-response message with the
 following properties:
 
-: max-pixel-fill-rate (required)
-:: The advertiser shall reply with the supported pixel fill rate in megapixels per
-    second. Requesting agents can use this information to make better-educated
-    decisions about what resolution and frame rates to stream content at.
-
-: supported-codecs (required)
+: codecs (required)
 :: The advertiser must indicate to the listener what codecs it understands for
-    remote playback.
+    remote playback. Note that the codec includes both (1) the codec name, and
+    (2) the max pixels per second supported for that codec.
 
 : min-resolution (optional)
 :: The advertiser may indicate what it considers its minimum resolution to be, for
@@ -350,17 +353,13 @@ following properties:
 :: The advertiser may indicate the maximum number of audio channels in abilities
     standard audio setup, e.g. 2 for stereo, 5 or 7 for a surround setup.
 
-: audio-bit-rate-limits (optional)
-:: The advertiser may indicate the practical audio bit rate limits, including the
-    minimum and maximum bit rates, and the maximum latency. Physical hardware
-    requirements, such as maximum decoder throughput or maximum audio buffer
-    size inform these values.
+: min-video-bit-rate (optional)
+:: The advertiser may indicate the practical min and max bit rate limits.
+    Physical hardware requirements, such as maximum decoder throughput or
+    maximum video buffer size inform these values.
 
-: video-bit-rate-limits (optional)
-:: The advertiser may indicate the practical audio bit rate limits, including the
-    minimum and maximum bit rates, and the maximum latency. Physical hardware
-    requirements, such as maximum decoder throughput or maximum video buffer
-    size inform these values.
+: max-video-bit-rate (optional)
+:: See min-video-bit-rate above.
 
 : aspect-ratio (optional)
 :: The advertiser may indicate what its ideal aspect ratio is, e.g. a 16:10

--- a/index.bs
+++ b/index.bs
@@ -331,50 +331,6 @@ The messages may contain the following properties:
 :: The requestee has to indicate that it supports video streaming. If false
     or not included, it is assumed video streaming is not supported.
 
-If the advertiser is already authenticated, the listener has the ability to
-request additional information by sending an streaming-capabilities-request
-message, and receive back a streaming-capabilities-response message with the
-following properties:
-
-: codecs (required)
-:: The advertiser must indicate to the listener what codecs it understands for
-    remote playback. Note that the codec includes both (1) the codec name, and
-    (2) the max pixels per second supported for that codec.
-
-: min-resolution (optional)
-:: The advertiser may indicate what it considers its minimum resolution to be, for
-    setting a minimum boundary on content quality.
-
-: max-resolution (optional)
-:: The advertiser may indicate the maximum resolution and frame rate. Note that
-    this may not be the ideal, depending on the max-pixel-fill-rate.
-
-: max-audio-channels (optional)
-:: The advertiser may indicate the maximum number of audio channels in abilities
-    standard audio setup, e.g. 2 for stereo, 5 or 7 for a surround setup.
-
-: min-video-bit-rate (optional)
-:: The advertiser may indicate the practical min and max bit rate limits.
-    Physical hardware requirements, such as maximum decoder throughput or
-    maximum video buffer size inform these values.
-
-: max-video-bit-rate (optional)
-:: See min-video-bit-rate above.
-
-: aspect-ratio (optional)
-:: The advertiser may indicate what its ideal aspect ratio is, e.g. a 16:10
-    display could return this value as 1.6 to indicate its preferred content
-    scaling.
-
-: color-profiles (optional)
-:: The advertiser may indicate what color profiles are understood, such as
-    sRGB v4. The listener may use these values to determine how to encode
-    video.
-
-: supports-scaling (optional)
-:: If omitted, this value is assumed to be false. Setting to "True" indicates
-    that the advertiser can scale content that is of an unsupported resolution or
-    non-ideal aspect ratio. If false, the listener must do the scaling.
 
 Listening agents act as QUIC clients.  Advertising agents act as QUIC servers.
 

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 1cff2db4ee2c3bba7a4077d3007528ec73b0485d" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="e048cf0cc3ccf1c426aff654035d623802a31b53" name="document-revision">
+  <meta content="1a5904fd8a04c5fe1ea7ff607726a94a4931c453" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1765,85 +1765,35 @@ Protocol uses mDNS but breaks compatibility with the metadata discovery process,
 it should change the DNS-SD service name to a new value, indicating a new
 mechanism for metadata discovery.</p>
    <h2 class="heading settled" data-level="4" id="transport"><span class="secno">4. </span><span class="content">Transport and metadata discovery with QUIC</span><a class="self-link" href="#transport"></a></h2>
-   <p>If a listening agent ("listener") wants to connect to an advertising agent
-("advertiser"), or to learn further metadata about it, it initiates a <a data-link-type="biblio" href="#biblio-quic">[QUIC]</a> connection to the IP and port from the SRV record.  Prior to authentication,
-a message may be exchanged (such as further metadata), but such info should be
-treated as unverified (such as indicating to a user that a display name of an
-unauthenticated agent is unverified).</p>
-   <p>To learn further metadata, the listener may send an agent-info-request
+   <p>If an agent wants to connect to or learn further metadata about another agent,
+it initiates a <a data-link-type="biblio" href="#biblio-quic">[QUIC]</a> connection to the IP and port from the SRV record.
+Prior to authentication, a message may be exchanged (such as further metadata),
+but such info should be treated as unverified (such as indicating to a user that
+a display name of an unauthenticated agent is unverified).</p>
+   <p>To learn further metadata, an agent may send an agent-info-request
 message (see <a href="#appendix-a">Appendix A: Messages</a>) and receive back an agent-info-response message.
-The messages may contain the following properties:</p>
+Any agent may send this request to learn about the capabilities of
+another device.</p>
+   <p>The agent-info-response messages contain the following properties:</p>
    <dl>
     <dt data-md>display-name (required)
     <dd data-md>
-     <p>The display name of the advertiser, intended to be displayed to a user by the
- listener. The listener should indicate through the UI if the advertiser
+     <p>The display name of the agent, intended to be displayed to a user by the
+ requester. The requester should indicate through the UI if the device
  is not authenticated or if the display name changes.</p>
     <dt data-md>model-name (optional)
     <dd data-md>
-     <p>If the advertiser is a hardware device, the model name of
+     <p>If the agent is a hardware device, the model name of
 the device.  This is used mainly for debugging purposes, but may be
 displayed to the user of the requesting agent.</p>
-    <dt data-md>audio-only (optional)
+    <dt data-md>supports-audio (optional)
     <dd data-md>
-     <p>Generally speaking, advertisers are assumed to support streaming both
-audio and video. If a advertiser wishes to indicate that they only support audio
-stream, they can pass this property as true. In that case, the listener
-should indicate through the UI that the advertiser is audio only.</p>
-   </dl>
-   <p>If the advertiser is already authenticated, the listener has the ability to
-request additional information by sending an streaming-capabilities-request
-message, and receive back a streaming-capabilities-response message with the
-following properties:</p>
-   <dl>
-    <dt data-md>max-pixel-fill-rate (required)
+     <p>The agent has to indicate that it supports audio streaming. If false
+or not included, it is assumed audio streaming is not supported.</p>
+    <dt data-md>supports-video (optional)
     <dd data-md>
-     <p>The advertiser shall reply with the supported pixel fill rate in megapixels per
-second. Requesting agents can use this information to make better-educated
-decisions about what resolution and frame rates to stream content at.</p>
-    <dt data-md>supported-codecs (required)
-    <dd data-md>
-     <p>The advertiser must indicate to the listener what codecs it understands for
-remote playback.</p>
-    <dt data-md>min-resolution (optional)
-    <dd data-md>
-     <p>The advertiser may indicate what it considers its minimum resolution to be, for
-setting a minimum boundary on content quality.</p>
-    <dt data-md>max-resolution (optional)
-    <dd data-md>
-     <p>The advertiser may indicate the maximum resolution and frame rate. Note that
-this may not be the ideal, depending on the max-pixel-fill-rate.</p>
-    <dt data-md>max-audio-channels (optional)
-    <dd data-md>
-     <p>The advertiser may indicate the maximum number of audio channels in abilities
-standard audio setup, e.g. 2 for stereo, 5 or 7 for a surround setup.</p>
-    <dt data-md>audio-bit-rate-limits (optional)
-    <dd data-md>
-     <p>The advertiser may indicate the practical audio bit rate limits, including the
-minimum and maximum bit rates, and the maximum latency. Physical hardware
-requirements, such as maximum decoder throughput or maximum audio buffer
-size inform these values.</p>
-    <dt data-md>video-bit-rate-limits (optional)
-    <dd data-md>
-     <p>The advertiser may indicate the practical audio bit rate limits, including the
-minimum and maximum bit rates, and the maximum latency. Physical hardware
-requirements, such as maximum decoder throughput or maximum video buffer
-size inform these values.</p>
-    <dt data-md>aspect-ratio (optional)
-    <dd data-md>
-     <p>The advertiser may indicate what its ideal aspect ratio is, e.g. a 16:10
-display could return this value as 1.6 to indicate its preferred content
-scaling.</p>
-    <dt data-md>color-profiles (optional)
-    <dd data-md>
-     <p>The advertiser may indicate what color profiles are understood, such as
-sRGB v4. The listener may use these values to determine how to encode
-video.</p>
-    <dt data-md>supports-scaling (optional)
-    <dd data-md>
-     <p>If omitted, this value is assumed to be false. Setting to "True" indicates
-that the advertiser can scale content that is of an unsupported resolution or
-non-ideal aspect ratio. If false, the listener must do the scaling.</p>
+     <p>The agent has to indicate that it supports video streaming. If false
+or not included, it is assumed video streaming is not supported.</p>
    </dl>
    <p>Listening agents act as QUIC clients.  Advertising agents act as QUIC servers.</p>
    <p>If a listening agent wishes to receive messages from an advertising agent or an
@@ -2859,64 +2809,11 @@ because smaller type keys encode on the wire smaller.</p>
 <span class="nx">  1</span><span class="p">:</span> <span class="nx">agent-info </span><span class="c1">; agent-info</span>
 <span class="p">}</span></p>
 
-<p><span class="nx">streaming-capabilities-request </span><span class="p">=</span> <span class="p">{</span>
-  <span class="nx">request</span>
-<span class="p">}</span></p>
-
-<p><span class="nx">streaming-capabilities-response </span><span class="p">=</span> <span class="p">{</span>
-  <span class="nx">response</span>
-<span class="nx">  1</span><span class="p">:</span> <span class="nx">streaming-capabilities </span><span class="c1">; streaming-capabilities</span>
-<span class="p">}</span></p>
-
-<p><span class="nx">streaming-capabilities-update </span><span class="p">=</span> <span class="p">{</span>
-  <span class="mi">1</span><span class="p">:</span> <span class="nx">streaming-capabilities </span><span class="c1">; streaming-capabilities</span>
-<span class="p">}</span></p>
-
 <p><span class="nx">agent-info </span><span class="p">=</span> <span class="p">{</span>
   <span class="mi">0</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; display-name</span>
   <span class="mi">1</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; model-name</span>
-  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; audio-only</span>
-<span class="p">}</span></p>
-
-<p><span class="nx">resolution </span><span class="p">=</span> <span class="p">{</span>
-  <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; horizontal-resolution</span>
-  <span class="mi">1</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; vertical-resolution</span>
-  <span class="mi">2</span><span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="o">*</span> <span class="kt">float64</span><span class="p">]</span> <span class="c1">; refresh-rates</span>
-<span class="p">}</span></p>
-
-<p><span class="nx">codec </span><span class="p">=</span> <span class="p">(</span>
-  <span class="nx">H-264</span><span class="p">:</span> <span class="mi">0</span>
-  <span class="nx">MPEG-4</span><span class="p">:</span> <span class="mi">1</span>
-  <span class="nx">MP3</span><span class="p">:</span> <span class="mi">2</span>
-  <span class="nx">VP8</span><span class="p">:</span> <span class="mi">3</span>
-  <span class="nx">AAC-LC</span><span class="p">:</span> <span class="mi">4</span>
-  <span class="nx">AC3</span><span class="p">:</span> <span class="mi">5</span>
-  <span class="nx">eAC3</span><span class="p">:</span> <span class="mi">6</span>
-  <span class="nx">FLAC</span><span class="p">:</span> <span class="mi">7</span>
-  <span class="nx">PCM</span><span class="p">:</span> <span class="mi">8</span>
-  <span class="nx">Vorbis</span><span class="p">:</span> <span class="mi">9</span>
-<span class="p">)</span></p>
-
-<p><span class="nx">bit-rate-limits </span><span class="p">=</span> <span class="p">{</span>
- <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; min-bit-rate</span>
- <span class="mi">1</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-bit-rate</span>
- <span class="mi">2</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-latency</span>
-<span class="p">}</span></p>
-
-<p><span class="nx">streaming-capabilities </span><span class="p">=</span> <span class="p">{</span>
-  <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-pixel-fill-rate</span>
-  <span class="mi">1</span><span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="o">*</span> <span class="nx">codec</span><span class="p">]</span> <span class="c1">; supported-codecs</span></p>
-
-<p><span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">resolution </span><span class="c1">; min-resolution</span>
-  <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">resolution </span><span class="c1">; max-resolution</span></p>
-
-<p><span class="p">?</span> <span class="mi">4</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-audio-channels</span>
-  <span class="p">?</span> <span class="mi">5</span><span class="p">:</span> <span class="nx">bit-rate-limits </span><span class="c1">; audio-bit-rate-limits</span>
-  <span class="p">?</span> <span class="mi">6</span><span class="p">:</span> <span class="nx">bit-rate-limits </span><span class="c1">; video-bit-rate-limits</span></p>
-
-<p><span class="p">?</span> <span class="mi">7</span><span class="p">:</span> <span class="kt">float64</span> <span class="c1">; aspect-ratio</span>
-  <span class="p">?</span> <span class="mi">8</span><span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="o">*</span> <span class="nx">string</span><span class="p">]</span> <span class="c1">; color-profiles</span>
-  <span class="p">?</span> <span class="mi">9</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; supports-scaling</span>
+  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; supports-audio</span>
+  <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; supports-video</span>
 <span class="p">}</span></p>
 
 <p><span class="c1">; type key 12</span>

--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version a816d78e14132d4d4d2ee44ccaf1b8bc90ac75d5" name="generator">
+  <meta content="Bikeshed version 1cff2db4ee2c3bba7a4077d3007528ec73b0485d" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="b7936b6165027da5c4a437cf05323e575eba10e6" name="document-revision">
+  <meta content="e048cf0cc3ccf1c426aff654035d623802a31b53" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1489,9 +1489,9 @@ pre .property::before, pre .property::after {
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
    <p>The Open Screen Protocol is a suite of network protocols that allow
 
-user agents to implement the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> and
-the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> in an interoperable
-fashion.</p>
+          user agents to implement the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> and
+          the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> in an interoperable
+          fashion.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
@@ -1638,7 +1638,7 @@ reasonably capable of rendering a specific <a data-link-type="dfn" href="https:/
      <p>A controlling user agent must be able to create a new <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection">PresentationConnection</a></code> to an existing presentation on the
 receiver, given its <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-request-url" id="ref-for-dfn-presentation-request-url③">presentation request URL</a> and <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-id" id="ref-for-dfn-presentation-id①">presentation ID</a>.</p>
     <li data-md>
-     <p>It must be possible to to close a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection①">PresentationConnection</a></code> between a
+     <p>It must be possible to close a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection①">PresentationConnection</a></code> between a
 controller and a presentation, and signal both parties with the
 reason why the connection was closed.</p>
     <li data-md>
@@ -1765,30 +1765,85 @@ Protocol uses mDNS but breaks compatibility with the metadata discovery process,
 it should change the DNS-SD service name to a new value, indicating a new
 mechanism for metadata discovery.</p>
    <h2 class="heading settled" data-level="4" id="transport"><span class="secno">4. </span><span class="content">Transport and metadata discovery with QUIC</span><a class="self-link" href="#transport"></a></h2>
-   <p>If a listening agent wants to connect to an advertising agent, or to
-learn further metadata about it, it initiates a <a data-link-type="biblio" href="#biblio-quic">[QUIC]</a> connection to
-the IP and port from the SRV record.  Prior to authentication, a message may be
-exchanged (such as further metadata), but such info should be treated as
-unverified (such as indicating to a user that a display name of an
+   <p>If a listening agent ("listener") wants to connect to an advertising agent
+("advertiser"), or to learn further metadata about it, it initiates a <a data-link-type="biblio" href="#biblio-quic">[QUIC]</a> connection to the IP and port from the SRV record.  Prior to authentication,
+a message may be exchanged (such as further metadata), but such info should be
+treated as unverified (such as indicating to a user that a display name of an
 unauthenticated agent is unverified).</p>
-   <p>To learn further metadata, an agent may send an agent-info-request
-message (see <a href="#appendix-a">Appendix A: Messages</a>) and receive back an agent-info-response message.  The
-messages may contain the following information with the following meaning:</p>
+   <p>To learn further metadata, the listener may send an agent-info-request
+message (see <a href="#appendix-a">Appendix A: Messages</a>) and receive back an agent-info-response message.
+The messages may contain the following properties:</p>
    <dl>
     <dt data-md>display-name (required)
     <dd data-md>
-     <p>The display name of the responding agent intended
-to be displayed to a user by the requesting agent.  If the responding agent
-is not yet authenticated, the requesting agent should make UI affordance for
-indicating to the user that the display name is not yet verified.  If the
-responding agent changes its display name, the requesting agent should
-make UI affordance for indicating to the user that the display name has
-changed.</p>
+     <p>The display name of the advertiser, intended to be displayed to a user by the
+ listener. The listener should indicate through the UI if the advertiser
+ is not authenticated or if the display name changes.</p>
     <dt data-md>model-name (optional)
     <dd data-md>
-     <p>If the agent is a hardware device, the model name of
+     <p>If the advertiser is a hardware device, the model name of
 the device.  This is used mainly for debugging purposes, but may be
 displayed to the user of the requesting agent.</p>
+    <dt data-md>audio-only (optional)
+    <dd data-md>
+     <p>Generally speaking, advertisers are assumed to support streaming both
+audio and video. If a advertiser wishes to indicate that they only support audio
+stream, they can pass this property as true. In that case, the listener
+should indicate through the UI that the advertiser is audio only.</p>
+   </dl>
+   <p>If the advertiser is already authenticated, the listener has the ability to
+request additional information by sending an streaming-capabilities-request
+message, and receive back a streaming-capabilities-response message with the
+following properties:</p>
+   <dl>
+    <dt data-md>max-pixel-fill-rate (required)
+    <dd data-md>
+     <p>The advertiser shall reply with the supported pixel fill rate in megapixels per
+second. Requesting agents can use this information to make better-educated
+decisions about what resolution and frame rates to stream content at.</p>
+    <dt data-md>supported-codecs (required)
+    <dd data-md>
+     <p>The advertiser must indicate to the listener what codecs it understands for
+remote playback.</p>
+    <dt data-md>min-resolution (optional)
+    <dd data-md>
+     <p>The advertiser may indicate what it considers its minimum resolution to be, for
+setting a minimum boundary on content quality.</p>
+    <dt data-md>max-resolution (optional)
+    <dd data-md>
+     <p>The advertiser may indicate the maximum resolution and frame rate. Note that
+this may not be the ideal, depending on the max-pixel-fill-rate.</p>
+    <dt data-md>max-audio-channels (optional)
+    <dd data-md>
+     <p>The advertiser may indicate the maximum number of audio channels in abilities
+standard audio setup, e.g. 2 for stereo, 5 or 7 for a surround setup.</p>
+    <dt data-md>audio-bit-rate-limits (optional)
+    <dd data-md>
+     <p>The advertiser may indicate the practical audio bit rate limits, including the
+minimum and maximum bit rates, and the maximum latency. Physical hardware
+requirements, such as maximum decoder throughput or maximum audio buffer
+size inform these values.</p>
+    <dt data-md>video-bit-rate-limits (optional)
+    <dd data-md>
+     <p>The advertiser may indicate the practical audio bit rate limits, including the
+minimum and maximum bit rates, and the maximum latency. Physical hardware
+requirements, such as maximum decoder throughput or maximum video buffer
+size inform these values.</p>
+    <dt data-md>aspect-ratio (optional)
+    <dd data-md>
+     <p>The advertiser may indicate what its ideal aspect ratio is, e.g. a 16:10
+display could return this value as 1.6 to indicate its preferred content
+scaling.</p>
+    <dt data-md>color-profiles (optional)
+    <dd data-md>
+     <p>The advertiser may indicate what color profiles are understood, such as
+sRGB v4. The listener may use these values to determine how to encode
+video.</p>
+    <dt data-md>supports-scaling (optional)
+    <dd data-md>
+     <p>If omitted, this value is assumed to be false. Setting to "True" indicates
+that the advertiser can scale content that is of an unsupported resolution or
+non-ideal aspect ratio. If false, the listener must do the scaling.</p>
    </dl>
    <p>Listening agents act as QUIC clients.  Advertising agents act as QUIC servers.</p>
    <p>If a listening agent wishes to receive messages from an advertising agent or an
@@ -2583,7 +2638,7 @@ QUIC connections.</p>
    <h4 class="heading settled" data-level="8.1.4" id="same-origin-policy-violations"><span class="secno">8.1.4. </span><span class="content">Same-Origin Policy Violations</span><a class="self-link" href="#same-origin-policy-violations"></a></h4>
    <p>The Presentation API allows cross-origin communication between controlling pages
 and presentations with the consent of each origin (through their use of the
-API).  This is similar to cross-origin communication via <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage" id="ref-for-dom-window-postmessage">postMessage()</a></code> with a target origin of <code>*</code>.  However, the Presentation
+API).  This is similar to cross-origin communication via <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage-options" id="ref-for-dom-window-postmessage-options">postMessage()</a></code> with a target origin of <code>*</code>.  However, the Presentation
 API does not convey source origin information with each message.  Therefore, the
 Open Screen Protocol does not convey origin information between its agents.</p>
    <p>The <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-id" id="ref-for-dfn-presentation-id③">presentation ID</a> carries some protection against unrestricted
@@ -2804,10 +2859,64 @@ because smaller type keys encode on the wire smaller.</p>
 <span class="nx">  1</span><span class="p">:</span> <span class="nx">agent-info </span><span class="c1">; agent-info</span>
 <span class="p">}</span></p>
 
+<p><span class="nx">streaming-capabilities-request </span><span class="p">=</span> <span class="p">{</span>
+  <span class="nx">request</span>
+<span class="p">}</span></p>
+
+<p><span class="nx">streaming-capabilities-response </span><span class="p">=</span> <span class="p">{</span>
+  <span class="nx">response</span>
+<span class="nx">  1</span><span class="p">:</span> <span class="nx">streaming-capabilities </span><span class="c1">; streaming-capabilities</span>
+<span class="p">}</span></p>
+
+<p><span class="nx">streaming-capabilities-update </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="nx">streaming-capabilities </span><span class="c1">; streaming-capabilities</span>
+<span class="p">}</span></p>
+
 <p><span class="nx">agent-info </span><span class="p">=</span> <span class="p">{</span>
-  <span class="mi">0</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; friendly-name</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; display-name</span>
   <span class="mi">1</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; model-name</span>
-  <span class="c1">; ...</span>
+  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; audio-only</span>
+<span class="p">}</span></p>
+
+<p><span class="nx">resolution </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; horizontal-resolution</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; vertical-resolution</span>
+  <span class="mi">2</span><span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="o">*</span> <span class="kt">float64</span><span class="p">]</span> <span class="c1">; refresh-rates</span>
+<span class="p">}</span></p>
+
+<p><span class="nx">codec </span><span class="p">=</span> <span class="p">(</span>
+  <span class="nx">H-264</span><span class="p">:</span> <span class="mi">0</span>
+  <span class="nx">MPEG-4</span><span class="p">:</span> <span class="mi">1</span>
+  <span class="nx">MP3</span><span class="p">:</span> <span class="mi">2</span>
+  <span class="nx">VP8</span><span class="p">:</span> <span class="mi">3</span>
+  <span class="nx">AAC-LC</span><span class="p">:</span> <span class="mi">4</span>
+  <span class="nx">AC3</span><span class="p">:</span> <span class="mi">5</span>
+  <span class="nx">eAC3</span><span class="p">:</span> <span class="mi">6</span>
+  <span class="nx">FLAC</span><span class="p">:</span> <span class="mi">7</span>
+  <span class="nx">PCM</span><span class="p">:</span> <span class="mi">8</span>
+  <span class="nx">Vorbis</span><span class="p">:</span> <span class="mi">9</span>
+<span class="p">)</span></p>
+
+<p><span class="nx">bit-rate-limits </span><span class="p">=</span> <span class="p">{</span>
+ <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; min-bit-rate</span>
+ <span class="mi">1</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-bit-rate</span>
+ <span class="mi">2</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-latency</span>
+<span class="p">}</span></p>
+
+<p><span class="nx">streaming-capabilities </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-pixel-fill-rate</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="o">*</span> <span class="nx">codec</span><span class="p">]</span> <span class="c1">; supported-codecs</span></p>
+
+<p><span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">resolution </span><span class="c1">; min-resolution</span>
+  <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">resolution </span><span class="c1">; max-resolution</span></p>
+
+<p><span class="p">?</span> <span class="mi">4</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-audio-channels</span>
+  <span class="p">?</span> <span class="mi">5</span><span class="p">:</span> <span class="nx">bit-rate-limits </span><span class="c1">; audio-bit-rate-limits</span>
+  <span class="p">?</span> <span class="mi">6</span><span class="p">:</span> <span class="nx">bit-rate-limits </span><span class="c1">; video-bit-rate-limits</span></p>
+
+<p><span class="p">?</span> <span class="mi">7</span><span class="p">:</span> <span class="kt">float64</span> <span class="c1">; aspect-ratio</span>
+  <span class="p">?</span> <span class="mi">8</span><span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="o">*</span> <span class="nx">string</span><span class="p">]</span> <span class="c1">; color-profiles</span>
+  <span class="p">?</span> <span class="mi">9</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; supports-scaling</span>
 <span class="p">}</span></p>
 
 <p><span class="c1">; type key 12</span>
@@ -3385,10 +3494,10 @@ because smaller type keys encode on the wire smaller.</p>
 })();
 </script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <aside class="dfn-panel" data-for="term-for-dom-window-postmessage">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-dom-window-postmessage-options">
+   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage-options">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage-options</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-window-postmessage">8.1.4. Same-Origin Policy Violations</a>
+    <li><a href="#ref-for-dom-window-postmessage-options">8.1.4. Same-Origin Policy Violations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-presentationconnection">
@@ -3497,7 +3606,7 @@ because smaller type keys encode on the wire smaller.</p>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-dom-window-postmessage" style="color:initial">postMessage(message, targetOrigin, transfer)</span>
+     <li><span class="dfn-paneled" id="term-for-dom-window-postmessage-options" style="color:initial">postMessage(message, options)</span>
     </ul>
    <li>
     <a data-link-type="biblio">[PRESENTATION-API]</a> defines the following terms:

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 1cff2db4ee2c3bba7a4077d3007528ec73b0485d" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="1a5904fd8a04c5fe1ea7ff607726a94a4931c453" name="document-revision">
+  <meta content="ea3c6aac3a6a66d40fa6477b76ace2774e393ee9" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1774,26 +1774,26 @@ a display name of an unauthenticated agent is unverified).</p>
 message (see <a href="#appendix-a">Appendix A: Messages</a>) and receive back an agent-info-response message.
 Any agent may send this request to learn about the capabilities of
 another device.</p>
-   <p>The agent-info-response messages contain the following properties:</p>
+   <p>The agent-info-response message contains the following properties:</p>
    <dl>
     <dt data-md>display-name (required)
     <dd data-md>
      <p>The display name of the agent, intended to be displayed to a user by the
- requester. The requester should indicate through the UI if the device
+ requester. The requester should indicate through the UI if the responder
  is not authenticated or if the display name changes.</p>
     <dt data-md>model-name (optional)
     <dd data-md>
      <p>If the agent is a hardware device, the model name of
 the device.  This is used mainly for debugging purposes, but may be
 displayed to the user of the requesting agent.</p>
-    <dt data-md>supports-audio (optional)
+    <dt data-md>receives-audio (optional)
     <dd data-md>
-     <p>The agent has to indicate that it supports audio streaming. If false
-or not included, it is assumed audio streaming is not supported.</p>
-    <dt data-md>supports-video (optional)
+     <p>The agent has to indicate that it supports audio. If false
+or not included, it is assumed audio content is not supported.</p>
+    <dt data-md>receives-video (optional)
     <dd data-md>
-     <p>The agent has to indicate that it supports video streaming. If false
-or not included, it is assumed video streaming is not supported.</p>
+     <p>The agent has to indicate that it supports video . If false
+or not included, it is assumed video content is not supported.</p>
    </dl>
    <p>Listening agents act as QUIC clients.  Advertising agents act as QUIC servers.</p>
    <p>If a listening agent wishes to receive messages from an advertising agent or an
@@ -1812,7 +1812,7 @@ timer expires, a agent-status-request message should be sent.</p>
    <p>If a client agent wishes to send messages to a server agent, the client
 agent can connect to the server agent "on demand"; it does not need to
 keep the connection alive.</p>
-   <p>The agent-info-response message and agent-status-response
+   <p>The agent-info-response and agent-status-response
 messages may be extended to include additional information not defined
 in this spec.  If done ad-hoc by applications and not in future specs,
 keys should be chosen to avoid collision, such as by choosing large
@@ -2812,8 +2812,8 @@ because smaller type keys encode on the wire smaller.</p>
 <p><span class="nx">agent-info </span><span class="p">=</span> <span class="p">{</span>
   <span class="mi">0</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; display-name</span>
   <span class="mi">1</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; model-name</span>
-  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; supports-audio</span>
-  <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; supports-video</span>
+  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; receives-audio</span>
+  <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; receives-video</span>
 <span class="p">}</span></p>
 
 <p><span class="c1">; type key 12</span>

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -12,8 +12,8 @@ agent-info-response = {
 agent-info = {
   0: text ; display-name
   1: text ; model-name
-  ? 2: bool ; supports-audio
-  ? 3: bool ; supports-video
+  ? 2: bool ; receives-audio
+  ? 3: bool ; receives-video
 }
 
 ; type key 12

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -25,7 +25,8 @@ streaming-capabilities-update = {
 agent-info = {
   0: text ; display-name
   1: text ; model-name
-  ? 2: bool ; audio-only
+  ? 2: bool ; supports-audio
+  ? 3: bool ; supports-video
 }
 
 resolution = {
@@ -34,39 +35,29 @@ resolution = {
   2: [1* float64] ; refresh-rates
 }
 
-codec = (
-  H-264: 0
-  MPEG-4: 1
-  MP3: 2
-  VP8: 3
-  AAC-LC: 4
-  AC3: 5
-  eAC3: 6
-  FLAC: 7
-  PCM: 8
-  Vorbis: 9
-)
-
 bit-rate-limits = {
  0: uint ; min-bit-rate
  1: uint ; max-bit-rate
- 2: uint ; max-latency
+}
+
+codec = {
+  0: string ; codec-name
+  1: uint ; max-pixels-per-second
 }
 
 streaming-capabilities = {
-  0: uint ; max-pixel-fill-rate
-  1: [1* codec] ; supported-codecs
+  0: [1* codec] ; codecs
 
-  ? 2: resolution ; min-resolution
-  ? 3: resolution ; max-resolution
+  ? 1: resolution ; min-resolution
+  ? 2: resolution ; max-resolution
 
-  ? 4: uint ; max-audio-channels
-  ? 5: bit-rate-limits ; audio-bit-rate-limits
-  ? 6: bit-rate-limits ; video-bit-rate-limits
+  ? 3: uint ; max-audio-channels
+  ? 4: uint ; min-video-bit-rate
+  ? 5: uint ; min-video-bit-rate
 
-  ? 7: float64 ; aspect-ratio
-  ? 8: [1* string] ; color-profiles
-  ? 9: bool ; supports-scaling
+  ? 6: float64 ; aspect-ratio
+  ? 7: [1* string] ; color-profiles
+  ? 8: bool ; supports-scaling
 }
 
 ; type key 12

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -9,10 +9,64 @@ agent-info-response = {
   1: agent-info ; agent-info
 }
 
+streaming-capabilities-request = {
+  request
+}
+
+streaming-capabilities-response = {
+  response
+  1: streaming-capabilities ; streaming-capabilities
+}
+
+streaming-capabilities-update = {
+  1: streaming-capabilities ; streaming-capabilities
+}
+
 agent-info = {
-  0: text ; friendly-name
+  0: text ; display-name
   1: text ; model-name
-  ; ...
+  ? 2: bool ; audio-only
+}
+
+resolution = {
+  0: uint ; horizontal-resolution
+  1: uint ; vertical-resolution
+  2: [1* float64] ; refresh-rates
+}
+
+codec = (
+  H-264: 0
+  MPEG-4: 1
+  MP3: 2
+  VP8: 3
+  AAC-LC: 4
+  AC3: 5
+  eAC3: 6
+  FLAC: 7
+  PCM: 8
+  Vorbis: 9
+)
+
+bit-rate-limits = {
+ 0: uint ; min-bit-rate
+ 1: uint ; max-bit-rate
+ 2: uint ; max-latency
+}
+
+streaming-capabilities = {
+  0: uint ; max-pixel-fill-rate
+  1: [1* codec] ; supported-codecs
+
+  ? 2: resolution ; min-resolution
+  ? 3: resolution ; max-resolution
+
+  ? 4: uint ; max-audio-channels
+  ? 5: bit-rate-limits ; audio-bit-rate-limits
+  ? 6: bit-rate-limits ; video-bit-rate-limits
+
+  ? 7: float64 ; aspect-ratio
+  ? 8: [1* string] ; color-profiles
+  ? 9: bool ; supports-scaling
 }
 
 ; type key 12

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -9,55 +9,11 @@ agent-info-response = {
   1: agent-info ; agent-info
 }
 
-streaming-capabilities-request = {
-  request
-}
-
-streaming-capabilities-response = {
-  response
-  1: streaming-capabilities ; streaming-capabilities
-}
-
-streaming-capabilities-update = {
-  1: streaming-capabilities ; streaming-capabilities
-}
-
 agent-info = {
   0: text ; display-name
   1: text ; model-name
   ? 2: bool ; supports-audio
   ? 3: bool ; supports-video
-}
-
-resolution = {
-  0: uint ; horizontal-resolution
-  1: uint ; vertical-resolution
-  2: [1* float64] ; refresh-rates
-}
-
-bit-rate-limits = {
- 0: uint ; min-bit-rate
- 1: uint ; max-bit-rate
-}
-
-codec = {
-  0: string ; codec-name
-  1: uint ; max-pixels-per-second
-}
-
-streaming-capabilities = {
-  0: [1* codec] ; codecs
-
-  ? 1: resolution ; min-resolution
-  ? 2: resolution ; max-resolution
-
-  ? 3: uint ; max-audio-channels
-  ? 4: uint ; min-video-bit-rate
-  ? 5: uint ; min-video-bit-rate
-
-  ? 6: float64 ; aspect-ratio
-  ? 7: [1* string] ; color-profiles
-  ? 8: bool ; supports-scaling
 }
 
 ; type key 12

--- a/messages_appendix.html
+++ b/messages_appendix.html
@@ -12,8 +12,8 @@
 <span class="nx">agent-info </span><span class="p">=</span> <span class="p">{</span>
   <span class="mi">0</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; display-name</span>
   <span class="mi">1</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; model-name</span>
-  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; supports-audio</span>
-  <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; supports-video</span>
+  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; receives-audio</span>
+  <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; receives-video</span>
 <span class="p">}</span>
 
 <span class="c1">; type key 12</span>

--- a/messages_appendix.html
+++ b/messages_appendix.html
@@ -9,64 +9,11 @@
 <span class="nx">  1</span><span class="p">:</span> <span class="nx">agent-info </span><span class="c1">; agent-info</span>
 <span class="p">}</span>
 
-<span class="nx">streaming-capabilities-request </span><span class="p">=</span> <span class="p">{</span>
-  <span class="nx">request</span>
-<span class="p">}</span>
-
-<span class="nx">streaming-capabilities-response </span><span class="p">=</span> <span class="p">{</span>
-  <span class="nx">response</span>
-<span class="nx">  1</span><span class="p">:</span> <span class="nx">streaming-capabilities </span><span class="c1">; streaming-capabilities</span>
-<span class="p">}</span>
-
-<span class="nx">streaming-capabilities-update </span><span class="p">=</span> <span class="p">{</span>
-  <span class="mi">1</span><span class="p">:</span> <span class="nx">streaming-capabilities </span><span class="c1">; streaming-capabilities</span>
-<span class="p">}</span>
-
 <span class="nx">agent-info </span><span class="p">=</span> <span class="p">{</span>
   <span class="mi">0</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; display-name</span>
   <span class="mi">1</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; model-name</span>
-  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; audio-only</span>
-<span class="p">}</span>
-
-<span class="nx">resolution </span><span class="p">=</span> <span class="p">{</span>
-  <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; horizontal-resolution</span>
-  <span class="mi">1</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; vertical-resolution</span>
-  <span class="mi">2</span><span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="o">*</span> <span class="kt">float64</span><span class="p">]</span> <span class="c1">; refresh-rates</span>
-<span class="p">}</span>
-
-<span class="nx">codec </span><span class="p">=</span> <span class="p">(</span>
-  <span class="nx">H-264</span><span class="p">:</span> <span class="mi">0</span>
-  <span class="nx">MPEG-4</span><span class="p">:</span> <span class="mi">1</span>
-  <span class="nx">MP3</span><span class="p">:</span> <span class="mi">2</span>
-  <span class="nx">VP8</span><span class="p">:</span> <span class="mi">3</span>
-  <span class="nx">AAC-LC</span><span class="p">:</span> <span class="mi">4</span>
-  <span class="nx">AC3</span><span class="p">:</span> <span class="mi">5</span>
-  <span class="nx">eAC3</span><span class="p">:</span> <span class="mi">6</span>
-  <span class="nx">FLAC</span><span class="p">:</span> <span class="mi">7</span>
-  <span class="nx">PCM</span><span class="p">:</span> <span class="mi">8</span>
-  <span class="nx">Vorbis</span><span class="p">:</span> <span class="mi">9</span>
-<span class="p">)</span>
-
-<span class="nx">bit-rate-limits </span><span class="p">=</span> <span class="p">{</span>
- <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; min-bit-rate</span>
- <span class="mi">1</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-bit-rate</span>
- <span class="mi">2</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-latency</span>
-<span class="p">}</span>
-
-<span class="nx">streaming-capabilities </span><span class="p">=</span> <span class="p">{</span>
-  <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-pixel-fill-rate</span>
-  <span class="mi">1</span><span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="o">*</span> <span class="nx">codec</span><span class="p">]</span> <span class="c1">; supported-codecs</span>
-
-  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">resolution </span><span class="c1">; min-resolution</span>
-  <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">resolution </span><span class="c1">; max-resolution</span>
-
-  <span class="p">?</span> <span class="mi">4</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-audio-channels</span>
-  <span class="p">?</span> <span class="mi">5</span><span class="p">:</span> <span class="nx">bit-rate-limits </span><span class="c1">; audio-bit-rate-limits</span>
-  <span class="p">?</span> <span class="mi">6</span><span class="p">:</span> <span class="nx">bit-rate-limits </span><span class="c1">; video-bit-rate-limits</span>
-
-  <span class="p">?</span> <span class="mi">7</span><span class="p">:</span> <span class="kt">float64</span> <span class="c1">; aspect-ratio</span>
-  <span class="p">?</span> <span class="mi">8</span><span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="o">*</span> <span class="nx">string</span><span class="p">]</span> <span class="c1">; color-profiles</span>
-  <span class="p">?</span> <span class="mi">9</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; supports-scaling</span>
+  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; supports-audio</span>
+  <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; supports-video</span>
 <span class="p">}</span>
 
 <span class="c1">; type key 12</span>

--- a/messages_appendix.html
+++ b/messages_appendix.html
@@ -9,10 +9,64 @@
 <span class="nx">  1</span><span class="p">:</span> <span class="nx">agent-info </span><span class="c1">; agent-info</span>
 <span class="p">}</span>
 
+<span class="nx">streaming-capabilities-request </span><span class="p">=</span> <span class="p">{</span>
+  <span class="nx">request</span>
+<span class="p">}</span>
+
+<span class="nx">streaming-capabilities-response </span><span class="p">=</span> <span class="p">{</span>
+  <span class="nx">response</span>
+<span class="nx">  1</span><span class="p">:</span> <span class="nx">streaming-capabilities </span><span class="c1">; streaming-capabilities</span>
+<span class="p">}</span>
+
+<span class="nx">streaming-capabilities-update </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="nx">streaming-capabilities </span><span class="c1">; streaming-capabilities</span>
+<span class="p">}</span>
+
 <span class="nx">agent-info </span><span class="p">=</span> <span class="p">{</span>
-  <span class="mi">0</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; friendly-name</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; display-name</span>
   <span class="mi">1</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; model-name</span>
-  <span class="c1">; ...</span>
+  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; audio-only</span>
+<span class="p">}</span>
+
+<span class="nx">resolution </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; horizontal-resolution</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; vertical-resolution</span>
+  <span class="mi">2</span><span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="o">*</span> <span class="kt">float64</span><span class="p">]</span> <span class="c1">; refresh-rates</span>
+<span class="p">}</span>
+
+<span class="nx">codec </span><span class="p">=</span> <span class="p">(</span>
+  <span class="nx">H-264</span><span class="p">:</span> <span class="mi">0</span>
+  <span class="nx">MPEG-4</span><span class="p">:</span> <span class="mi">1</span>
+  <span class="nx">MP3</span><span class="p">:</span> <span class="mi">2</span>
+  <span class="nx">VP8</span><span class="p">:</span> <span class="mi">3</span>
+  <span class="nx">AAC-LC</span><span class="p">:</span> <span class="mi">4</span>
+  <span class="nx">AC3</span><span class="p">:</span> <span class="mi">5</span>
+  <span class="nx">eAC3</span><span class="p">:</span> <span class="mi">6</span>
+  <span class="nx">FLAC</span><span class="p">:</span> <span class="mi">7</span>
+  <span class="nx">PCM</span><span class="p">:</span> <span class="mi">8</span>
+  <span class="nx">Vorbis</span><span class="p">:</span> <span class="mi">9</span>
+<span class="p">)</span>
+
+<span class="nx">bit-rate-limits </span><span class="p">=</span> <span class="p">{</span>
+ <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; min-bit-rate</span>
+ <span class="mi">1</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-bit-rate</span>
+ <span class="mi">2</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-latency</span>
+<span class="p">}</span>
+
+<span class="nx">streaming-capabilities </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-pixel-fill-rate</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="o">*</span> <span class="nx">codec</span><span class="p">]</span> <span class="c1">; supported-codecs</span>
+
+  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">resolution </span><span class="c1">; min-resolution</span>
+  <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">resolution </span><span class="c1">; max-resolution</span>
+
+  <span class="p">?</span> <span class="mi">4</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; max-audio-channels</span>
+  <span class="p">?</span> <span class="mi">5</span><span class="p">:</span> <span class="nx">bit-rate-limits </span><span class="c1">; audio-bit-rate-limits</span>
+  <span class="p">?</span> <span class="mi">6</span><span class="p">:</span> <span class="nx">bit-rate-limits </span><span class="c1">; video-bit-rate-limits</span>
+
+  <span class="p">?</span> <span class="mi">7</span><span class="p">:</span> <span class="kt">float64</span> <span class="c1">; aspect-ratio</span>
+  <span class="p">?</span> <span class="mi">8</span><span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="o">*</span> <span class="nx">string</span><span class="p">]</span> <span class="c1">; color-profiles</span>
+  <span class="p">?</span> <span class="mi">9</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; supports-scaling</span>
 <span class="p">}</span>
 
 <span class="c1">; type key 12</span>


### PR DESCRIPTION
This patch adds specifications for getting device capabilities through the open screen protocol. Specifically, what types of actions and media does the receiver support?

NOTE: This patch is based on @pthatcherg's remote playback pull request, so make sure to exclude those commits when diffing!