### PR TITLE
Cleanup line wrapping, spelling errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,7 +7,10 @@ ED: https://webscreens.github.io/openscreenprotocol/
 Canonical URL: ED
 Editor: Mark Foltz, Google, https://github.com/mfoltzgoogle, w3cid 68454
 Repository: webscreens/openscreenprotocol
-Abstract: The Open Screen Protocol is a suite of network protocols that allow user agents to implement the [[PRESENTATION-API|Presentation API]] and the [[REMOTE-PLAYBACK|Remote Playback API]] in an interoperable fashion.
+Abstract: The Open Screen Protocol is a suite of network protocols that allow
+          user agents to implement the [[PRESENTATION-API|Presentation API]] and
+          the [[REMOTE-PLAYBACK|Remote Playback API]] in an interoperable
+          fashion.
 Group: Second Screen Community Group
 Mailing List: public-webscreens@w3c.org
 Mailing List Archives: https://lists.w3.org/Archives/Public/public-webscreens/
@@ -15,11 +18,19 @@ Markup Shorthands: markdown yes, dfn yes, idl yes
 </pre>
 
 <p boilerplate="copyright">
-<a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © [YEAR] the Contributors to the [TITLE] Specification, published by the <a href="https://www.w3.org/community/webscreens/">Second Screen Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
-A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.
+<a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">
+  Copyright</a> © [YEAR] the Contributors to the [TITLE] Specification,
+  published by the <a href="https://www.w3.org/community/webscreens/">
+  Second Screen Community Group</a> under the
+  <a href="https://www.w3.org/community/about/agreements/cla/">
+  W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable
+<a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a>
+is available.
 </p>
 
-<!-- TODO: Add short names to Presentation API spec, so that BS autolinking works as designed. -->
+<!-- TODO: Add short names to Presentation API spec,
+           so that BS autolinking works as designed. -->
 <!-- TODO: Can autolinks to HTML51 be automatically generated? -->
 <pre class="anchors">
 urlPrefix: https://w3c.github.io/presentation-api/#dfn-; type: dfn; spec: PRESENTATION-API
@@ -459,14 +470,14 @@ For hkdf-of-scrypt-of-psk, the proof is calculated using the following steps:
     the responder in the QUIC crypto handshake during connection establishment.
 
 9. Let proof be the result of running
-     [\HKDF](https://tools.ietf.org/html/rfc5869) on scryptResult with 
+     [\HKDF](https://tools.ietf.org/html/rfc5869) on scryptResult with
      both the extract and expand steps, hash function hashFunction,
      application-specific info, and output key length keyLength.
 
 To verify that the responder's proof is correct, the challenger makes the same
 calculation of the proof and compares the result. If the results are the same,
 the challenger considers the responder authenticated, and considers it
-unauthenticated otherwise.  
+unauthenticated otherwise.
 
 Note: the values of 32 above (for salt length, keyLength) are based on the
 output size of sha-256.  If a different hash mechanism is used in the future,
@@ -496,7 +507,7 @@ To learn which receivers are [=available presentation displays=] for a
 particular URL or set of URLs, the controller may send a
 presentation-url-availability-request message with the following values:
 
-: urls 
+: urls
 :: A list of presentation URLs.  Must not be empty.
 
 : watch-duration
@@ -554,7 +565,7 @@ values:
 : url
 :: The selected presentation URL
 
-: headers 
+: headers
 :: headers that the receiver should use to fetch the
     presentationUrl.  For example,
     [[PRESENTATION-API#establishing-a-presentation-connection|section 6.6.1]] of
@@ -743,8 +754,8 @@ This section defines the use of the Open Screen Protocol for starting, terminati
 and controlling remote playback of media as defined by the
 [[REMOTE-PLAYBACK|Remote Playback API]].  [[#remote-playback-api]] defines how
 APIs in [[REMOTE-PLAYBACK|Remote Playback API]] map to the protocol messages
-defined in this section.  
- 
+defined in this section.
+
 For all messages defined in this section, see Appendix A for the full
 CDDL definitions.
 
@@ -764,7 +775,7 @@ following values:
 :: A list of [=media resources=].  Must not be empty.
 
 <!-- TODO: Should we allow different headers for different URLs? -->
-: headers 
+: headers
 :: headers that the receiver should use to fetch the
     urls.  For example,
     [[REMOTE-PLAYBACK#establishing-a-connection-with-a-remote-playback-device|section 6.2.4 of
@@ -783,7 +794,7 @@ following values:
 
 In response, the receiver should send a remote-playback-availability-response
 message with the following values:
-  
+
 : url-availabilities
 :: A list of URL availability states.  Each state must correspond to the matching URL
     from the request by list index.
@@ -807,7 +818,7 @@ have changed in availability state within the watch duration of the original
 availability request.
 
 To save power, the controller may disconnect the QUIC connection and
-later reconnect to send availablity requests and receive availability
+later reconnect to send availability requests and receive availability
 responses and updates. The QUIC connection ID may or may not be the same
 when reconnecting.  Note that the lifetime of a watch-id is not limited
 to one QUIC connection.  The receiver must continue sending updates for watches
@@ -819,7 +830,7 @@ To start remote playback, the controller may send a
 remote-playback-start-request message to the receiver with the following
 values:
 
-: remote-playback-id 
+: remote-playback-id
 :: An identifier that uniquely identifies the remote playback from the
     controller to the receiver.  It does not need to be unique across all remote
     playbacks from that controllers to all receivers nor unique across all remote
@@ -857,7 +868,7 @@ If the controller wishes to modify the state of the remote playback (for
 example, to pause, resume, skip, etc), it may send a
 remote-playback-modify-request message with the following values:
 
-: remote-playback-id 
+: remote-playback-id
 :: The ID of the remote playback to be modified.
 
 : controls
@@ -875,7 +886,7 @@ the controller (such as when the skips or pauses due to user user interaction on
 the receiver), the receiver may send a remote-playback-state-event to the
 controller.
 
-: remote-playback-id 
+: remote-playback-id
 :: The ID of the remote playback whose state has changed.
 
 : state
@@ -886,7 +897,7 @@ controller.
 To terminate the remote playback, the controller may send a
 remote-playback-termination-request message with the following values:
 
-: remote-playback-id 
+: remote-playback-id
 :: The ID of the remote playback to terminate.
 
 : reason
@@ -910,7 +921,7 @@ As mentioned in
 API section 6.2.7]], terminating the remote playback means the controller is no
 longer controlling the remote playback and does not necessarily stop media from
 rendering on the receiver.  Whether or not the receiver stops rendering media depends
-upon the implmentation of the receiver.
+upon the implementation of the receiver.
 
 Remote Playback State and Controls {#remote-playback-state-and-controls}
 ------------------------------------------------------------------------
@@ -934,9 +945,9 @@ intentionally mirror settable attributes and methods of the
     [HtmlMediaElement.src](https://html.spec.whatwg.org/multipage/media.html#dom-media-src)
     for more details. Must not be used in the initial controls of the
     remote-playback-start-request message (which already contains a list of URLs).
- 
+
 : preload
-:: Set how aggresively to preload media. See
+:: Set how aggressively to preload media. See
     [HtmlMediaElement.preload](https://html.spec.whatwg.org/multipage/media.html#dom-media-preload)
     for more details. Should only be used in the initial controls of the
     remote-playback-start-request message or when the source is changed.  If not
@@ -951,7 +962,7 @@ intentionally mirror settable attributes and methods of the
     remote-playback-start-request.  If not set in the initial controls, it is
     assumed to be false.
 
-: paused 
+: paused
 :: If true, pause; if false, resume. See
     [HtmlMediaElement.pause()](https://html.spec.whatwg.org/multipage/media.html#dom-media-pause).
     and
@@ -974,7 +985,7 @@ intentionally mirror settable attributes and methods of the
 : seek
 :: Seek to a precise time. See
     [HtmlMediaElement.currentTime](https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime)
-    for more details. 
+    for more details.
 
 : fast-seek
 :: Seek to an approximate time as fast as possible. See
@@ -1011,8 +1022,8 @@ intentionally mirror settable attributes and methods of the
     [HtmlMediaElement.addTextTrack](https://html.spec.whatwg.org/multipage/media.html#dom-media-addtexttrack)
     for more details.  This is optional for the receiver to support and if not
     supported, the receiver will behave as though it were never set.
-    
-: changed-text-tracks 
+
+: changed-text-tracks
 :: Change text tracks by ID.  All other text tracks are left
     unchanged.  Set the mode, add cues, and remove cues by id. See
     [HtmlMediaElement.textTracks](https://html.spec.whatwg.org/multipage/media.html#dom-media-texttracks)
@@ -1060,14 +1071,14 @@ changed.
 
 : error
 :: A major error occurred which prevents the remote playback from continuing. See
-    [HtmlMediaElement.error](https://html.spec.whatwg.org/multipage/media.html#dom-media-error) and 
+    [HtmlMediaElement.error](https://html.spec.whatwg.org/multipage/media.html#dom-media-error) and
     [HtmlMediaElement media error codes](https://html.spec.whatwg.org/multipage/media.html#concept-mediaerror-code).
     The default is no error
     for the initial state in the remote-playback-start-response message.
 
 : epoch
 :: The "zero time" of the media timeline. See
-    [HtmlMediaElement's timeline offset](https://html.spec.whatwg.org/multipage/media.html#timeline-offset) and 
+    [HtmlMediaElement's timeline offset](https://html.spec.whatwg.org/multipage/media.html#timeline-offset) and
     [HtmlMediaElement.getStartDate()](https://html.spec.whatwg.org/multipage/media.html#dom-media-getstartdate).
     The default is an unknown epoch
     for the initial state in the remote-playback-start-response message.
@@ -1178,7 +1189,7 @@ based on an implementation specific discovery mechanism" and
 implementation specific mechanism)", the user agent may use the
 mDNS, QUIC, agent-info-request, and remote-playback-availability messages
 defined previously in this spec to discover [=remote playback devices=].  The
-remote-playback-availiability urls must contain the [=availability sources set=].
+remote-playback-availability urls must contain the [=availability sources set=].
 
 When
 [[REMOTE-PLAYBACK#establishing-a-connection-with-a-remote-playback-device|section
@@ -1247,7 +1258,7 @@ flows on the QUIC connection, or by observing cryptographic timing.
 
 Active attackers, such as compromised routers, will be able to manipulate data
 exchanged between agents.  They can inject traffic into existing QUIC
-connections and attempt to inititate new QUIC connections.  These abilities can
+connections and attempt to initiate new QUIC connections.  These abilities can
 be used to attempt the following:
 
 *   Impersonate an agent or one already trusted by the user, in an attempt
@@ -1255,7 +1266,7 @@ be used to attempt the following:
 *   Connect to an agent and query its capabilities.
 *   Connect to and control a presentation or remote playback, or extract data
     from the application state of the presentation or remote playback.
-    
+
 One particular attack of concern is misconfigured or compromised routers that
 expose local network devices (such as Open Screen Protocol agents) to the
 Internet.  This vector of attack has been used by malicious parties to take
@@ -1314,7 +1325,7 @@ considered public and untrusted data:
 1. IP addresses and ports used by the Open Screen Protocol.
 1. Data advertised through mDNS, including the display name prefix, the
     certificate fingerprint, and the metadata version.
-   
+
 ### Cross Origin State Considerations ### {#cross-origin-state}
 
 Access to origin state across browsing sessions is possible through the
@@ -1415,7 +1426,7 @@ Mitigation Strategies {#security-mitigations}
 ### Local passive network attackers ### {#local-passive-mitigations}
 
 Local passive attackers may attempt to harvest data about user activities and
-device capabilties using the Open Screen Protocol.  The main strategy to address
+device capabilities using the Open Screen Protocol.  The main strategy to address
 this is data minimization, by only exposing opaque public key fingerprints
 before user-mediated authentication takes place.
 
@@ -1446,11 +1457,11 @@ should be flagged include:
     already-trusted agent.
 * Already-trusted agents whose metadata provided through the `agent-info`
     message has changed.
-  
+
 Flagging means that the user is notified of the attempt at impersonation.  In
 the last case, the user should be required to re-authenticate to the
 already-trusted agent to verify its identity.
-  
+
 The second is through management of the low-entropy secret during mutual
 authentication:
 
@@ -1472,7 +1483,7 @@ Issue(130): [Security] Review attack and mitigation considerations for TLS 1.3
 Unfortunately, we cannot rely on network devices to fully protect Open Screen
 Protocol agents, because a misconfigured firewall or NAT could expose a
 LAN-connected agent to the broader Internet.  Open Screen Protocol agents
-should be secure against attack from any Inernet host.
+should be secure against attack from any Internet host.
 
 Issue(131): [Security] Mitigations for remote network attackers
 
@@ -1558,7 +1569,7 @@ response = (
 
 request-id = uint
 
-; type key 1001 
+; type key 1001
 authentication-request = {
   request
   1: authentication-mechanism ; mechanism
@@ -1566,7 +1577,7 @@ authentication-request = {
   3: uint ; cost
 }
 
-; type key 1002 
+; type key 1002
 authentication-response = {
   response
   1: authentication-response-result ; result
@@ -1828,7 +1839,7 @@ remote-playback-state-event = {
   2: remote-playback-state ; state
 }
 
-remote-playback-id = uint 
+remote-playback-id = uint
 
 remote-playback-controls = {
   ? 1: url ; source
@@ -1836,10 +1847,10 @@ remote-playback-controls = {
   ? 3: bool ; loop
   ? 4: bool ; paused
   ? 5: bool ; muted
-  ? 6: float ; volume 
+  ? 6: float ; volume
   ? 7: media-time ; seek
   ? 8: media-time ; fast-seek
-  ? 9: float ; playback-rate 
+  ? 9: float ; playback-rate
   ? 10: url ; poster
   ? 11: [* text] ; enabled-audio-track-ids
   ? 12: text ; selected-video-track-id
@@ -1921,7 +1932,7 @@ text-track-cue = {
 }
 
 media-time-range = [
-  start: media-time, 
+  start: media-time,
   end: media-time
 ]
 
@@ -1930,7 +1941,7 @@ media-time = [
   scale: uint
 ]
 
-unknown = 0 
+unknown = 0
 forever = 1
 
 media-error = [

--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 9c6ae748322940994300e90a77c34437364b40a6" name="generator">
+  <meta content="Bikeshed version 1cff2db4ee2c3bba7a4077d3007528ec73b0485d" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="3e0675f2a5988fafb4a697958a7314c695dfdb42" name="document-revision">
+  <meta content="3352f7845a594242cbbaf9d9c5c9d496309d63a3" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1403,7 +1403,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-03-25">25 March 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-04-03">3 April 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1418,13 +1418,18 @@ pre .property::before, pre .property::after {
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2019 the Contributors to the Open Screen Protocol Specification, published by the <a href="https://www.w3.org/community/webscreens/">Second Screen Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+   <p class="copyright" data-fill-with="copyright"> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright"> Copyright</a> © 2019 the Contributors to the Open Screen Protocol Specification,
+  published by the <a href="https://www.w3.org/community/webscreens/"> Second Screen Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/"> W3C Community Contributor License Agreement (CLA)</a>.
 A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>The Open Screen Protocol is a suite of network protocols that allow user agents to implement the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> and the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> in an interoperable fashion.</p>
+   <p>The Open Screen Protocol is a suite of network protocols that allow
+
+          user agents to implement the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> and
+          the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> in an interoperable
+          fashion.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
@@ -1540,7 +1545,9 @@ existing APIs, or new APIs.</p>
 the agent that is used to discover and initiate presentation of Web content on
 another device the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-controller" id="ref-for-dfn-controller">controller</a> (or <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent" id="ref-for-dfn-controlling-user-agent">controlling user agent</a> when it is a
 browser).  We call the agent on the device rendering the Web content the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-receiver" id="ref-for-dfn-receiver">receiver</a> or <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-display" id="ref-for-dfn-presentation-display">presentation display</a> (or <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent" id="ref-for-dfn-receiving-user-agent">receiving user agent</a> when it is
-a browser). <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-display-availability" id="ref-for-dfn-presentation-display-availability">presentation display availability</a> refers to whether or not a <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-receiver" id="ref-for-dfn-receiver①">receiver</a> is compatible with a <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-request-url" id="ref-for-dfn-presentation-request-url">presentation request URL</a></p>
+a browser). <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-display-availability" id="ref-for-dfn-presentation-display-availability">presentation display availability</a> refers to whether or not a <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-receiver" id="ref-for-dfn-receiver①">receiver</a> is compatible with a <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-request-url" id="ref-for-dfn-presentation-request-url">presentation request URL</a>.  However, in the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a>, a "controller" refers to as a specific
+browsing context within the browser, whereas here the "controller" refers to the
+browser itself, although it may be acting on behalf of a browsing context.</p>
    <p>We borrow terminology from the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a>.  The
 agent responsible for rendering media of a remote playback is called the <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-remote-playback-devices" id="ref-for-dfn-remote-playback-devices">remote playback device</a>. In this document, we also refer to it as the <em>receiver</em> because it is shorter and keeps terminology consistent between
 presentations and remote playbacks. Similarly, we use the term "controller"
@@ -1855,7 +1862,7 @@ the responder in the QUIC crypto handshake during connection establishment.</p>
    </ul>
    <ol start="9">
     <li data-md>
-     <p>Let proof be the result of running <a href="https://tools.ietf.org/html/rfc5869">\HKDF</a> on scryptResult with 
+     <p>Let proof be the result of running <a href="https://tools.ietf.org/html/rfc5869">\HKDF</a> on scryptResult with
  both the extract and expand steps, hash function hashFunction,
  application-specific info, and output key length keyLength.</p>
    </ol>
@@ -1883,25 +1890,25 @@ presentation-url-availability-request message with the following values:</p>
     <dt data-md>watch-duration
     <dd data-md>
      <p>The period of time that the controller is interested in receiving updates
-about the URLs, should the availability change.</p>
+about their URLs, should the availability change.</p>
     <dt data-md>watch-id
     <dd data-md>
-     <p>An identifier the receiver may use when sending updates about URL
+     <p>An identifier the receiver must use when sending updates about URL
 availability so that the controller knows which URLs the receiver is referring
-to.</p>
+to.  The controller must choose a value that is unique across all
+presentation URL availability watches to the same receiver.</p>
    </dl>
    <p>In response, the receiver should send one presentation-url-availability-response
 message with the following values:</p>
    <dl>
     <dt data-md>url-availabilities
     <dd data-md>
-     <p>A list of URL availability states (available,
-unavailable, or invalid).  Each state must correspond to the matching URL
+     <p>A list of URL availability states.  Each state must correspond to the matching URL
 from the request by list index.</p>
    </dl>
-   <p>The receivers should later (up to the current time plus request
-watch-duration) send presentation-url-availability-event messages if
-URL availabilities change.  Such events contain the following values:</p>
+   <p>While the watch is valid (the watch-duration has not expired), the receivers
+should send remote-playback-availability-event messages when URL availabilities change.
+Such events contain the following values:</p>
    <dl>
     <dt data-md>watch-id
     <dd data-md>
@@ -1909,8 +1916,7 @@ URL availabilities change.  Such events contain the following values:</p>
 used to refer to the presentation URLs whose availability has changed.</p>
     <dt data-md>url-availabilities
     <dd data-md>
-     <p>A list of URL availability states (available,
-unavailable, or invalid).  Each state must correspond to the URLs from the
+     <p>A list of URL availability states.  Each state must correspond to the URLs from the
 request referred to by the watch-id.</p>
    </dl>
    <p>Note that these messages are not broadcasted to all controllers. They are sent
@@ -1918,18 +1924,22 @@ individually to controllers that have requested availability for the URLs that
 have changed in availability state within the watch duration of the original
 availability request.</p>
    <p>To save power, the controller may disconnect the QUIC connection and
-later reconnect to send availablity requests and receive availability
-responses and updates.</p>
+later reconnect to send availability requests and receive availability
+responses and updates.  The QUIC connection ID may or may not be the same
+when reconnecting.  Note that the lifetime of a watch-id is not limited
+to one QUIC connection.  The receiver must continue sending updates for watches
+even if the QUIC connection changes, and thus controller need not send
+new URL availability requests if the QUIC connection changes.</p>
    <p>To start a presentation, the controller may send a
 presentation-start-request message to the receiver with the following
 values:</p>
    <dl>
     <dt data-md>presentation-id
     <dd data-md>
-     <p>the presentation identifier</p>
+     <p>The presentation identifier</p>
     <dt data-md>url
     <dd data-md>
-     <p>the selected presentation URL</p>
+     <p>The selected presentation URL</p>
     <dt data-md>headers
     <dd data-md>
      <p>headers that the receiver should use to fetch the
@@ -1962,7 +1972,7 @@ presentation-connection-message with the following values:</p>
 presentation-connection-open-response messages.</p>
     <dt data-md>message
     <dd data-md>
-     <p>the presentation message data.</p>
+     <p>The presentation message data.</p>
    </dl>
    <p>To terminate a presentation, the controller may send a
 presentation-termination-request message with the following values:</p>
@@ -2079,13 +2089,392 @@ agent</a> may send a presentation-termination-request message.</p>
 controlling browsing context using an implementation specific
 mechanism", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent" id="ref-for-dfn-receiving-user-agent①">receiving user agent</a> must receive and process the
 presentation-connection-open-request.</p>
-   <p>When <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> <a href="https://www.w3.org/TR/presentation-api/#monitoring-incoming-presentation-connections">section
-6.7.1</a> says "Establish the connection between the controlling and receiving browsing
-contexts using an implementation specific mechanism.", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent" id="ref-for-dfn-receiving-user-agent②">receiving user
-agent</a>, must send a presentation-connection-open-response message.</p>
-   <h3 class="heading settled" data-level="7.3" id="remote-playback"><span class="secno">7.3. </span><span class="content">Remote Playback API Protocol</span><a class="self-link" href="#remote-playback"></a></h3>
-   <p class="issue" id="issue-eaed3698"><a class="self-link" href="#issue-eaed3698"></a> Propose control protocol for Remote
-Playback API. <a href="https://github.com/webscreens/openscreenprotocol/issues/12">&lt;https://github.com/webscreens/openscreenprotocol/issues/12></a></p>
+   <p>When <a href="https://www.w3.org/TR/presentation-api/#monitoring-incoming-presentation-connections">section
+6.7.1</a> says "Establish the connection between the controlling and receiving
+browsing contexts using an implementation specific mechanism.", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent" id="ref-for-dfn-receiving-user-agent②">receiving
+user agent</a>, must send a presentation-connection-open-response message.</p>
+   <h3 class="heading settled" data-level="7.3" id="remote-playback-protocol"><span class="secno">7.3. </span><span class="content">Remote Playback Protocol</span><a class="self-link" href="#remote-playback-protocol"></a></h3>
+   <p>This section defines the use of the Open Screen Protocol for starting, terminating,
+and controlling remote playback of media as defined by the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a>. <a href="#remote-playback-api">§7.5 Remote Playback API</a> defines how
+APIs in <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> map to the protocol messages
+defined in this section.</p>
+   <p>For all messages defined in this section, see Appendix A for the full
+CDDL definitions.</p>
+   <p>To learn which receivers are <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-compatible-remote-playback-device" id="ref-for-dfn-compatible-remote-playback-device">compatible remote playback device</a>s (also called
+available <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-remote-playback-devices" id="ref-for-dfn-remote-playback-devices①">remote playback devices</a>) for a particular URL or set of URLs, the
+controller may send a remote-playback-availability-request message with the
+following values:</p>
+   <dl>
+    <dt data-md>urls
+    <dd data-md>
+     <p>A list of <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-media-resources" id="ref-for-dfn-media-resources">media resources</a>.  Must not be empty.</p>
+    <dt data-md>headers
+    <dd data-md>
+     <p>headers that the receiver should use to fetch the
+urls.  For example, <a href="https://www.w3.org/TR/remote-playback/#establishing-a-connection-with-a-remote-playback-device">section 6.2.4 of
+the Remote Playback API</a> says that the Accept-Language header should be
+provided.</p>
+    <dt data-md>watch-duration
+    <dd data-md>
+     <p>The period of time that the controller is interested in receiving updates
+about their URLs, should the availability change.</p>
+    <dt data-md>watch-id
+    <dd data-md>
+     <p>An identifier the receiver must use when sending updates about URL
+availability so that the controller knows which URLs the receiver is referring
+to. The controller must choose a value that is unique across all
+remote playback availability watches to the same receiver.</p>
+   </dl>
+   <p>In response, the receiver should send a remote-playback-availability-response
+message with the following values:</p>
+   <dl>
+    <dt data-md>url-availabilities
+    <dd data-md>
+     <p>A list of URL availability states.  Each state must correspond to the matching URL
+from the request by list index.</p>
+   </dl>
+   <p>The receivers should later (up to the current time plus request
+watch-duration) send remote-playback-availability-event  messages if
+URL availabilities change.  Such events contain the following values:</p>
+   <dl>
+    <dt data-md>watch-id
+    <dd data-md>
+     <p>The watch-id given in the remote-playback-url-availability-response,
+used to refer to the remote playback URLs whose availability has changed.</p>
+    <dt data-md>url-availabilities
+    <dd data-md>
+     <p>A list of URL availability states.  Each state must correspond to the URLs from the
+request referred to by the watch-id.</p>
+   </dl>
+   <p>Note that these messages are not broadcasted to all controllers. They are sent
+individually to controllers that have requested availability for the URLs that
+have changed in availability state within the watch duration of the original
+availability request.</p>
+   <p>To save power, the controller may disconnect the QUIC connection and
+later reconnect to send availability requests and receive availability
+responses and updates. The QUIC connection ID may or may not be the same
+when reconnecting.  Note that the lifetime of a watch-id is not limited
+to one QUIC connection.  The receiver must continue sending updates for watches
+even if the QUIC connection changes, and thus controller need not send
+new URL availability requests if the QUIC connection changes.</p>
+   <p>To start remote playback, the controller may send a
+remote-playback-start-request message to the receiver with the following
+values:</p>
+   <dl>
+    <dt data-md>remote-playback-id
+    <dd data-md>
+     <p>An identifier that uniquely identifies the remote playback from the
+controller to the receiver.  It does not need to be unique across all remote
+playbacks from that controllers to all receivers nor unique across all remote
+playbacks from all controllers to that receivers.</p>
+    <dt data-md>urls
+    <dd data-md>
+     <p>The <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-media-resources" id="ref-for-dfn-media-resources①">media resources</a> that the controller has selected for playback on the
+receiver.</p>
+    <dt data-md>text-track-urls
+    <dd data-md>
+     <p>URLs of text tracks associated with the <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-media-resources" id="ref-for-dfn-media-resources②">media resources</a>.</p>
+    <dt data-md>controls
+    <dd data-md>
+     <p>Initial controls for modifying the initial state of the remote playback, as
+defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.  The controller may send
+controls that are optional for the receiver to support before it knows the
+receiver supports them.  If the receiver does not support them, it will
+ignore them and the controller will learn that it does not support them from
+the remote-playback-start-response message.</p>
+   </dl>
+   <p>When the receiver receives a remote-playback-start-request message, it should
+send back a remote-playback-start-response message.  It should do so quickly,
+usually before the <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-media-resources" id="ref-for-dfn-media-resources③">media resource</a> has been loaded and instead give updates
+of the progress of  loading with remote-playback-state-event messages, unless
+the receiver decides to not attempt to load the resource at all.  If it chooses
+not to, it must respond with the appropriate failure result (such as timeout or
+invalid-url).  Additionally, the response must include the following:</p>
+   <dl>
+    <dt data-md>state
+    <dd data-md>
+     <p>The initial state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.</p>
+   </dl>
+   <p>If the controller wishes to modify the state of the remote playback (for
+example, to pause, resume, skip, etc), it may send a
+remote-playback-modify-request message with the following values:</p>
+   <dl>
+    <dt data-md>remote-playback-id
+    <dd data-md>
+     <p>The ID of the remote playback to be modified.</p>
+    <dt data-md>controls
+    <dd data-md>
+     <p>Updated controls as defined in {#remote-playback-state-and-controls}</p>
+   </dl>
+   <p>When a receiver receives a remote-playback-modify-request it should send a
+remote-playback-modify-response message in reply with the following values:</p>
+   <dl>
+    <dt data-md>state
+    <dd data-md>
+     <p>The updated state of the remote playback as defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.</p>
+   </dl>
+   <p>When the state of remote playback changes without request for modification from
+the controller (such as when the skips or pauses due to user user interaction on
+the receiver), the receiver may send a remote-playback-state-event to the
+controller.</p>
+   <dl>
+    <dt data-md>remote-playback-id
+    <dd data-md>
+     <p>The ID of the remote playback whose state has changed.</p>
+    <dt data-md>state
+    <dd data-md>
+     <p>The updated state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.</p>
+   </dl>
+   <p>To terminate the remote playback, the controller may send a
+remote-playback-termination-request message with the following values:</p>
+   <dl>
+    <dt data-md>remote-playback-id
+    <dd data-md>
+     <p>The ID of the remote playback to terminate.</p>
+    <dt data-md>reason
+    <dd data-md>
+     <p>The reason the remote playback is being terminated.</p>
+   </dl>
+   <p>When a receiver receives a remote-playback-termination-request, it should
+send back a remote-playback-termination-response message to the controller.</p>
+   <p>If a receiver terminates a remote playback without a request from the controller
+to do so, it must send a remote-playback-termination-event message to the
+controller with the following values:</p>
+   <dl>
+    <dt data-md>remote-playback-id
+    <dd data-md>
+     <p>The ID of the remote playback that was terminated.</p>
+    <dt data-md>reason
+    <dd data-md>
+     <p>The reason the remote playback was terminated.</p>
+   </dl>
+   <p>As mentioned in <a href="https://www.w3.org/TR/remote-playback/#disconnecting-from-a-remote-playback-device">Remote Playback
+API section 6.2.7</a>, terminating the remote playback means the controller is no
+longer controlling the remote playback and does not necessarily stop media from
+rendering on the receiver.  Whether or not the receiver stops rendering media depends
+upon the implementation of the receiver.</p>
+   <h3 class="heading settled" data-level="7.4" id="remote-playback-state-and-controls"><span class="secno">7.4. </span><span class="content">Remote Playback State and Controls</span><a class="self-link" href="#remote-playback-state-and-controls"></a></h3>
+   <p>In order for the controller and receiver to stay in sync with regards to the
+state of the remote playback, the controller may send controls to modify the state
+(for example, via the remote-playback-modify-request message) and the receiver
+may send updates about state changes (for example, via the
+remote-playback-state-event message).</p>
+   <p>The controls sent by the controller include the following individual control
+values, each of which is optional.  This allows the controller to change one
+control value or many control values at once without having to specify all
+control values every time.  A non-present control value indicates no change.  A
+present control value indicates the change defined below. These controls
+intentionally mirror settable attributes and methods of the <a href="https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement">HtmlMediaElement</a>.</p>
+   <dl>
+    <dt data-md>source
+    <dd data-md>
+     <p>Change the <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-media-resources" id="ref-for-dfn-media-resources④">media resource</a> URL. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-src">HtmlMediaElement.src</a> for more details. Must not be used in the initial controls of the
+remote-playback-start-request message (which already contains a list of URLs).</p>
+    <dt data-md>preload
+    <dd data-md>
+     <p>Set how aggressively to preload media. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-preload">HtmlMediaElement.preload</a> for more details. Should only be used in the initial controls of the
+remote-playback-start-request message or when the source is changed.  If not
+set in the initial controls, it is left to the receiver to decide.  This is
+optional for the receiver to support and if not supported, the receiver will
+behave as though it were never set.</p>
+    <dt data-md>loop
+    <dd data-md>
+     <p>Set whether or not to loop media. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-loop">HtmlMediaElement.loop</a> for more details. Should only be used in the initial control of the
+remote-playback-start-request.  If not set in the initial controls, it is
+assumed to be false.</p>
+    <dt data-md>paused
+    <dd data-md>
+     <p>If true, pause; if false, resume. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-pause">HtmlMediaElement.pause()</a>.
+and <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-play">HtmlMediaElement.play()</a> for more details.  If not set in the initial controls, it is left to the
+receiver to decide.</p>
+    <dt data-md>muted
+    <dd data-md>
+     <p>If true, mute; if false, unmute. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-muted">HtmlMediaElement.muted</a> for more details.  If not set in the initial controls, it is left to the
+receiver to decide.</p>
+    <dt data-md>volume
+    <dd data-md>
+     <p>Set the audio volume in the range from 0.0 to 1.0 inclusive. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-volume">HtmlMediaElement.volume</a> for more details.  If not set in the initial controls, it is left to the
+receiver to decide.</p>
+    <dt data-md>seek
+    <dd data-md>
+     <p>Seek to a precise time. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime">HtmlMediaElement.currentTime</a> for more details.</p>
+    <dt data-md>fast-seek
+    <dd data-md>
+     <p>Seek to an approximate time as fast as possible. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-fastseek">HtmlMediaElement.fastSeek()</a> for more details.</p>
+    <dt data-md>playback-rate
+    <dd data-md>
+     <p>Set the rate a which the media plays. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate">HtmlMediaElement.playbackRate</a> for more details.  If not set in the initial controls, it is left to the
+receiver to decide.  This is optional for the receiver to support and if not
+supported, the receiver will behave as though it were never set.</p>
+    <dt data-md>poster
+    <dd data-md>
+     <p>Set the URL of an image to show when video data is not available. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-poster">HtmlMediaElement.poster</a> for more details. If not set in the initial controls, no poster is used and
+the receiver can choose what to render when video data is unavailable.  This
+is optional for the receiver to support and if not supported, the receiver
+will behave as though it were never set.</p>
+    <dt data-md>enabled-audio-track-ids
+    <dd data-md>
+     <p>Enable included audio tracks by ID and disable all other audio tracks. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-audiotracks">HtmlMediaElement.audioTracks</a> for more details.</p>
+    <dt data-md>select-video-track-id
+    <dd data-md>
+     <p>Select the given video track by ID and unselect all other video tracks. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-videotracks">HtmlMediaElement.videoTracks</a> for more details.</p>
+    <dt data-md>added-text-tracks
+    <dd data-md>
+     <p>Add text tracks with the given kinds, labels, and languages. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-addtexttrack">HtmlMediaElement.addTextTrack</a> for more details.  This is optional for the receiver to support and if not
+supported, the receiver will behave as though it were never set.</p>
+    <dt data-md>changed-text-tracks
+    <dd data-md>
+     <p>Change text tracks by ID.  All other text tracks are left
+unchanged.  Set the mode, add cues, and remove cues by id. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-texttracks">HtmlMediaElement.textTracks</a> for more details.  Note that future specifications or extensions to this
+specifications are expected to add new properties to the text-track-cue
+(such as text size, alignment, position, etc).  Adding and removing
+cues is optional for the receiver to support and if not supported, the
+receiver will behave as though no cues were added or removed (both adding
+and removing are indicated via the support for "added-cues").  As specified in <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-texttracks">HtmlMediaElement.textTracks</a>,
+if a cue ID is invalid (removing an un-added ID or adding an ID twice, for example),
+the receiver may reject the text track change.</p>
+   </dl>
+   <p>The states sent by the receiver include the following individual state values,
+each of which is optional.  This allows the receiver to update the controller
+about more than one state value at once without having to specify all
+state values every time.  A non-present state value indicates the state has not
+changed.</p>
+   <dl>
+    <dt data-md>supports
+    <dd data-md>
+     <p>The controls the receiver supports.  These may differ for different <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-media-resources" id="ref-for-dfn-media-resources⑤">media
+resource</a>s and should not changes unless the <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-media-resources" id="ref-for-dfn-media-resources⑥">media resource</a> changes.
+The default is empty (support for nothing)
+for the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>source
+    <dd data-md>
+     <p>The current <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-media-resources" id="ref-for-dfn-media-resources⑦">media resource</a> URL. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currentsrc">HtmlMediaElement.currentSrc</a>.
+Must be present in the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>loading
+    <dd data-md>
+     <p>The state of network activity for loading the <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-media-resources" id="ref-for-dfn-media-resources⑧">media resource</a>. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-networkstate">HtmlMediaElement.networkState</a>.
+The default is empty (NETWORK_EMPTY)
+for the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>loaded
+    <dd data-md>
+     <p>The state of the loaded media (whether enough is loaded to play). See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate">HtmlMediaElement.readyState</a>.
+The default is nothing (HAVE_NOTHING)
+for the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>error
+    <dd data-md>
+     <p>A major error occurred which prevents the remote playback from continuing. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-error">HtmlMediaElement.error</a> and <a href="https://html.spec.whatwg.org/multipage/media.html#concept-mediaerror-code">HtmlMediaElement media error codes</a>.
+The default is no error
+for the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>epoch
+    <dd data-md>
+     <p>The "zero time" of the media timeline. See <a href="https://html.spec.whatwg.org/multipage/media.html#timeline-offset">HtmlMediaElement’s timeline offset</a> and <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-getstartdate">HtmlMediaElement.getStartDate()</a>.
+The default is an unknown epoch
+for the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>duration
+    <dd data-md>
+     <p>The duration of the media timeline. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-duration">HtmlMediaElement.duration</a>.
+The default is an unknown duration
+for the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>buffered-time-ranges
+    <dd data-md>
+     <p>The time ranges for which media has been buffered. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-buffered">HtmlMediaElement.buffered</a>.</p>
+    <dt data-md>played-time-ranges
+    <dd data-md>
+     <p>The time ranges reached by the playback position during normal playback. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-played">HtmlMediaElement.played</a>.</p>
+    <dt data-md>seekable-time-ranges
+    <dd data-md>
+     <p>The time ranges for which media is seekable by the controller or the receiver. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-seekable">HtmlMediaElement.seekable</a>.</p>
+    <dt data-md>position
+    <dd data-md>
+     <p>The playback position. See <a href="https://html.spec.whatwg.org/multipage/media.html#official-playback-position">HtmlMediaElement’s official playback
+position</a> and <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime">HtmlMediaElement.currentTime</a>.
+The default is 0
+for the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>playbackRate
+    <dd data-md>
+     <p>The current rate of playback on a scale where 1.0 is "normal speed". See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate">HtmlMediaElement.playbackRate</a>.
+The default is 1.0
+for the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>paused
+    <dd data-md>
+     <p>Whether media is paused or not. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-paused">HtmlMediaElement.paused</a>.
+The default is false
+for the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>seeking
+    <dd data-md>
+     <p>Whether the receiver is seeking or not. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-seeking">HtmlMediaElement.seeking</a>.
+The default is false
+for the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>stalled
+    <dd data-md>
+     <p>If true, media is not playing because not enough media is loaded, and false otherwise. See <a href="https://html.spec.whatwg.org/multipage/media.html#event-media-stalled">HtmlMediaElement.stalled</a>.
+The default is false
+for the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>ended
+    <dd data-md>
+     <p>Whether media has reached the end or not. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-ended">HtmlMediaElement.ended</a>.
+The default is false
+for the initial state in the remote-playback-start-response message.</p>
+    <dt data-md>volume
+    <dd data-md>
+     <p>The current volume of playback on a scale of 0.0 to 1.0. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-volume">HtmlMediaElement.volume</a>.</p>
+    <dt data-md>muted
+    <dd data-md>
+     <p>True if audio is muted (overriding the volume value) and false otherwise.
+See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-muted">HtmlMediaElement.muted</a>.</p>
+    <dt data-md>resolution
+    <dd data-md>
+     <p>The "intrinsic width" and "intrinsic width" of the video. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-videowidth">HtmlMediaElement.videoWidth</a> and <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-videoheight">HtmlMediaElement.videoHeight</a>.</p>
+    <dt data-md>audio-tracks
+    <dd data-md>
+     <p>The available audio tracks, which can individually enabled or disabled. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-audiotracks">HtmlMediaElement.audioTracks</a></p>
+    <dt data-md>video-tracks
+    <dd data-md>
+     <p>The available video tracks.  Only one may be selected. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-videotracks">HtmlMediaElement.videoTracks</a></p>
+    <dt data-md>text-tracks
+    <dd data-md>
+     <p>The available text tracks, which can be individually shown, hidden, or disabled. See <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-videotracks">HtmlMediaElement.textTracks</a>.
+The controller can also add cues to and remove cues from text tracks.</p>
+   </dl>
+   <p>All times, time ranges, and durations (such as position, duration, and
+seekable-time-ranges) used above use a common media-time value (see Appendix A)
+which includes a time scale.  This allows time values which work on different
+time scales to be expressed without loss of precision.  The scale is represented
+in hertz, such as 90000 for 90000hz, a common time scale for video.</p>
+   <h3 class="heading settled" data-level="7.5" id="remote-playback-api"><span class="secno">7.5. </span><span class="content">Remote Playback API</span><a class="self-link" href="#remote-playback-api"></a></h3>
+   <p>This section defines how the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> uses the
+messages defined in <a href="#remote-playback-protocol">§7.3 Remote Playback Protocol</a>.</p>
+   <p>When <a href="https://www.w3.org/TR/remote-playback/#the-list-of-available-remote-playback-devices">section
+6.2.1.2</a> says "This list contains remote playback devices and is populated
+based on an implementation specific discovery mechanism" and <a href="https://www.w3.org/TR/remote-playback/#the-list-of-available-remote-playback-devices">section
+6.2.1.4</a> says "Retrieve available remote playback devices (using an
+implementation specific mechanism)", the user agent may use the
+mDNS, QUIC, agent-info-request, and remote-playback-availability messages
+defined previously in this spec to discover <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-remote-playback-devices" id="ref-for-dfn-remote-playback-devices②">remote playback devices</a>.  The
+remote-playback-availability urls must contain the <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-availability-sources-set" id="ref-for-dfn-availability-sources-set">availability sources set</a>.</p>
+   <p>When <a href="https://www.w3.org/TR/remote-playback/#establishing-a-connection-with-a-remote-playback-device">section
+6.2.4</a> says "Request connection of remote to device. The implementation of this
+step is specific to the user agent." and  "Synchronize the current media element
+state with the remote playback state", the user agent may send the
+remote-playback-start-request message to start remote playback.  The
+remote-playback-start-request urls must contain the <a data-link-type="dfn" href="https://w3c.github.io/remote-playback/#dfn-remote-playback-source" id="ref-for-dfn-remote-playback-source">remote playback source</a>.
+The current <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> only allows a single source,
+but the protocol allows for several and future versions of <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> may allow for several.</p>
+   <p>When <a href="https://www.w3.org/TR/remote-playback/#establishing-a-connection-with-a-remote-playback-device">section
+6.2.4</a> says "The mechanism that is used to connect the user agent with the
+remote playback device and play the remote playback source is an implementation
+choice of the user agent. The connection will likely have to provide a two-way
+messaging abstraction capable of carrying media commands to the remote playback
+device and receiving media playback state in order to keep the media element
+state and remote playback state in sync", the user agent may send
+remote-playback-modify-request messages to change the remote playback state
+based on changes to the local media element and receive
+remote-playback-modify-response and remote-playback-state-event messages to
+change the local media element based on changes to the remote playback state.</p>
+   <p>When <a href="https://www.w3.org/TR/remote-playback/#establishing-a-connection-with-a-remote-playback-device">section
+6.2.7</a> says "Request disconnection of remote from the device. The
+implementation of this step is specific to the user agent.", the controlling
+user agent may send the remote-playback-termination-request message.</p>
    <h2 class="heading settled" data-level="8" id="security-privacy"><span class="secno">8. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security-privacy"></a></h2>
    <p>The Open Screen Protocol allows two networked agents to discover each other
 and exchange user and application data.  As such, its security and privacy
@@ -2107,7 +2496,7 @@ flows on the QUIC connection, or by observing cryptographic timing.</p>
    <h4 class="heading settled" data-level="8.1.2" id="active-network-attackers"><span class="secno">8.1.2. </span><span class="content">Active Network Attackers</span><a class="self-link" href="#active-network-attackers"></a></h4>
    <p>Active attackers, such as compromised routers, will be able to manipulate data
 exchanged between agents.  They can inject traffic into existing QUIC
-connections and attempt to inititate new QUIC connections.  These abilities can
+connections and attempt to initiate new QUIC connections.  These abilities can
 be used to attempt the following:</p>
    <ul>
     <li data-md>
@@ -2257,7 +2646,7 @@ exchanged.</p>
    <h3 class="heading settled" data-level="8.5" id="security-mitigations"><span class="secno">8.5. </span><span class="content">Mitigation Strategies</span><a class="self-link" href="#security-mitigations"></a></h3>
    <h4 class="heading settled" data-level="8.5.1" id="local-passive-mitigations"><span class="secno">8.5.1. </span><span class="content">Local passive network attackers</span><a class="self-link" href="#local-passive-mitigations"></a></h4>
    <p>Local passive attackers may attempt to harvest data about user activities and
-device capabilties using the Open Screen Protocol.  The main strategy to address
+device capabilities using the Open Screen Protocol.  The main strategy to address
 this is data minimization, by only exposing opaque public key fingerprints
 before user-mediated authentication takes place.</p>
    <p>Passive attackers may also attempt timing attacks to learn the
@@ -2313,7 +2702,7 @@ by a correct implementation of TLS 1.3.</p>
    <p>Unfortunately, we cannot rely on network devices to fully protect Open Screen
 Protocol agents, because a misconfigured firewall or NAT could expose a
 LAN-connected agent to the broader Internet.  Open Screen Protocol agents
-should be secure against attack from any Inernet host.</p>
+should be secure against attack from any Internet host.</p>
    <p class="issue" id="issue-1353180f"><a class="self-link" href="#issue-1353180f"></a> [Security] Mitigations for remote network attackers <a href="https://github.com/webscreens/openscreenprotocol/issues/131">&lt;https://github.com/webscreens/openscreenprotocol/issues/131></a></p>
    <h4 class="heading settled" data-level="8.5.4" id="denial-of-service-mitigations"><span class="secno">8.5.4. </span><span class="content">Denial of service</span><a class="self-link" href="#denial-of-service-mitigations"></a></h4>
    <p>It will be difficult to completely prevent denial service of attacks that
@@ -2382,7 +2771,7 @@ response = (
 
 request-id = uint
 
-; type key 1001 
+; type key 1001
 authentication-request = {
   request
   1: authentication-mechanism ; mechanism
@@ -2390,7 +2779,7 @@ authentication-request = {
   3: uint ; cost
 }
 
-; type key 1002 
+; type key 1002
 authentication-response = {
   response
   1: authentication-response-result ; result
@@ -2652,7 +3041,7 @@ remote-playback-state-event = {
   2: remote-playback-state ; state
 }
 
-remote-playback-id = uint 
+remote-playback-id = uint
 
 remote-playback-controls = {
   ? 1: url ; source
@@ -2660,10 +3049,10 @@ remote-playback-controls = {
   ? 3: bool ; loop
   ? 4: bool ; paused
   ? 5: bool ; muted
-  ? 6: float ; volume 
+  ? 6: float ; volume
   ? 7: media-time ; seek
   ? 8: media-time ; fast-seek
-  ? 9: float ; playback-rate 
+  ? 9: float ; playback-rate
   ? 10: url ; poster
   ? 11: [* text] ; enabled-audio-track-ids
   ? 12: text ; selected-video-track-id
@@ -2672,7 +3061,7 @@ remote-playback-controls = {
 }
 
 remote-playback-state = {
-  ? 1: (rate: bool, preload: bool, poster: bool, added-text-track: bool, added-cues: bool) ; supports
+  ? 1: &amp;(rate: bool, preload: bool, poster: bool, added-text-track: bool, added-cues: bool) ; supports
 
   ? 2: url ; source
   ? 3: &amp;(
@@ -2683,7 +3072,7 @@ remote-playback-state = {
   ) ; loading
   ? 4: &amp;(
     nothing: 0
-    metdata: 1
+    metadata: 1
     current: 2
     future: 3
     enough: 4
@@ -2745,7 +3134,7 @@ text-track-cue = {
 }
 
 media-time-range = [
-  start: media-time, 
+  start: media-time,
   end: media-time
 ]
 
@@ -2754,7 +3143,7 @@ media-time = [
   scale: uint
 ]
 
-unknown = 0 
+unknown = 0
 forever = 1
 
 media-error = [
@@ -2763,6 +3152,7 @@ media-error = [
     network-error: 2
     decode-error: 3
     source-not-supported: 4
+    unknown-error: 5
   )
   message: text
 ]
@@ -2783,7 +3173,7 @@ video-track-state = {
   5 : bool ; selected
 }
 
-track-track-state = {
+text-track-state = {
   track-state
   6 : mode ; text-track-mode
 }
@@ -2943,12 +3333,6 @@ track-track-state = {
     <li><a href="#ref-for-dom-window-postmessage-options">8.1.4. Same-Origin Policy Violations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-element">
-   <a href="https://www.w3.org/TR/html51/single-page.html#media-element">https://www.w3.org/TR/html51/single-page.html#media-element</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-media-element">1.1. Terminology</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-presentationconnection">
    <a href="https://w3c.github.io/presentation-api/#presentationconnection">https://w3c.github.io/presentation-api/#presentationconnection</a><b>Referenced in:</b>
    <ul>
@@ -3058,11 +3442,6 @@ track-track-state = {
      <li><span class="dfn-paneled" id="term-for-dom-window-postmessage-options" style="color:initial">postMessage(message, options)</span>
     </ul>
    <li>
-    <a data-link-type="biblio">[html51]</a> defines the following terms:
-    <ul>
-     <li><span class="dfn-paneled" id="term-for-media-element" style="color:initial">media element</span>
-    </ul>
-   <li>
     <a data-link-type="biblio">[PRESENTATION-API]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-presentationconnection" style="color:initial">PresentationConnection</span>
@@ -3091,8 +3470,6 @@ track-track-state = {
   <dl>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
-   <dt id="biblio-html51">[HTML51]
-   <dd>Steve Faulkner; et al. <a href="https://www.w3.org/TR/html51/">HTML 5.1 2nd Edition</a>. 3 October 2017. REC. URL: <a href="https://www.w3.org/TR/html51/">https://www.w3.org/TR/html51/</a>
    <dt id="biblio-presentation-api">[PRESENTATION-API]
    <dd>Mark Foltz; Dominik Röttsches. <a href="https://www.w3.org/TR/presentation-api/">Presentation API</a>. 1 June 2017. CR. URL: <a href="https://www.w3.org/TR/presentation-api/">https://www.w3.org/TR/presentation-api/</a>
    <dt id="biblio-remote-playback">[REMOTE-PLAYBACK]
@@ -3110,14 +3487,14 @@ track-track-state = {
    <dd>S. Cheshire; M. Krochmal. <a href="https://tools.ietf.org/html/rfc6762">Multicast DNS</a>. February 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6762">https://tools.ietf.org/html/rfc6762</a>
    <dt id="biblio-rfc6763">[RFC6763]
    <dd>S. Cheshire; M. Krochmal. <a href="https://tools.ietf.org/html/rfc6763">DNS-Based Service Discovery</a>. February 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6763">https://tools.ietf.org/html/rfc6763</a>
+   <dt id="biblio-rfc7049">[RFC7049]
+   <dd>C. Bormann; P. Hoffman. <a href="https://tools.ietf.org/html/rfc7049">Concise Binary Object Representation (CBOR)</a>. October 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7049">https://tools.ietf.org/html/rfc7049</a>
    <dt id="biblio-security-privacy-questionnaire">[SECURITY-PRIVACY-QUESTIONNAIRE]
    <dd>Mike West. <a href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire: Security and Privacy</a>. 10 December 2015. NOTE. URL: <a href="https://www.w3.org/TR/security-privacy-questionnaire/">https://www.w3.org/TR/security-privacy-questionnaire/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
    <div class="issue"> Requirements for Remote Playback API <a href="https://github.com/webscreens/openscreenprotocol/issues/3">&lt;https://github.com/webscreens/openscreenprotocol/issues/3></a><a href="#issue-a1f35a95"> ↵ </a></div>
-   <div class="issue"> Propose control protocol for Remote
-Playback API. <a href="https://github.com/webscreens/openscreenprotocol/issues/12">&lt;https://github.com/webscreens/openscreenprotocol/issues/12></a><a href="#issue-eaed3698"> ↵ </a></div>
    <div class="issue"> [Privacy] Fate of metadata / authentication history when clearing
 browsing data <a href="https://github.com/webscreens/openscreenprotocol/issues/132">&lt;https://github.com/webscreens/openscreenprotocol/issues/132></a><a href="#issue-7d9298b1"> ↵ </a></div>
    <div class="issue"> [Security] Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a><a href="#issue-5107ff88"> ↵ </a></div>


### PR DESCRIPTION
This patch is a minor patch, focused on removing spelling errors and
cleaning up line endings, e.g. extra long lines and trailing whitespace.