### PR TITLE
Add explanation of integer key usage

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1514,7 +1514,12 @@ Appendix A: Messages {#appendix-a}
 
 The following messages are defined with [[CDDL]]. When
 integer keys are used, a comment is appended to the line to indicate
-the name of the field. Each root message (one that can be put into a
+the name of the field. This unusual syntax is consistently applied for object
+definitions in this specification due to it resulting in significantly smaller
+objects over-the-wire. Integer keys are used instead of object arrays to allow
+for easy indexing of optional fields.
+
+Each root message (one that can be put into a
 QUIC stream without being enclosed by another message) has a comment
 indicating the message type key.
 

--- a/index.bs
+++ b/index.bs
@@ -1514,10 +1514,10 @@ Appendix A: Messages {#appendix-a}
 
 The following messages are defined with [[CDDL]]. When
 integer keys are used, a comment is appended to the line to indicate
-the name of the field. This unusual syntax is consistently applied for object
-definitions in this specification due to it resulting in significantly smaller
-objects over-the-wire. Integer keys are used instead of object arrays to allow
-for easy indexing of optional fields.
+the name of the field. Object definitions in this specification have this
+unusual syntax to reduce the number of bytes-on-the-wire, while maintaining a
+human-readable name for each key. Integer keys are used instead of object arrays
+to allow for easy indexing of optional fields.
 
 Each root message (one that can be put into a
 QUIC stream without being enclosed by another message) has a comment

--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version a816d78e14132d4d4d2ee44ccaf1b8bc90ac75d5" name="generator">
+  <meta content="Bikeshed version 4d208866a95a1121fceca549a36bfb09c5bf1705" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="b6bbe38abfddce18ee408aca68ee1029e9e3e20b" name="document-revision">
+  <meta content="fc0788aebd5ff2b54bcd3f188ed0b53c1888769c" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-04-04">4 April 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-04-13">13 April 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1489,9 +1489,9 @@ pre .property::before, pre .property::after {
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
    <p>The Open Screen Protocol is a suite of network protocols that allow
 
-user agents to implement the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> and
-the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> in an interoperable
-fashion.</p>
+          user agents to implement the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> and
+          the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> in an interoperable
+          fashion.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
@@ -2586,7 +2586,7 @@ QUIC connections.</p>
    <h4 class="heading settled" data-level="8.1.4" id="same-origin-policy-violations"><span class="secno">8.1.4. </span><span class="content">Same-Origin Policy Violations</span><a class="self-link" href="#same-origin-policy-violations"></a></h4>
    <p>The Presentation API allows cross-origin communication between controlling pages
 and presentations with the consent of each origin (through their use of the
-API).  This is similar to cross-origin communication via <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage" id="ref-for-dom-window-postmessage">postMessage()</a></code> with a target origin of <code>*</code>.  However, the Presentation
+API).  This is similar to cross-origin communication via <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage-options" id="ref-for-dom-window-postmessage-options">postMessage()</a></code> with a target origin of <code>*</code>.  However, the Presentation
 API does not convey source origin information with each message.  Therefore, the
 Open Screen Protocol does not convey origin information between its agents.</p>
    <p>The <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-id" id="ref-for-dfn-presentation-id③">presentation ID</a> carries some protection against unrestricted
@@ -2784,7 +2784,11 @@ persistent exploits.</p>
    <h2 class="heading settled" id="appendix-a"><span class="content">Appendix A: Messages</span><a class="self-link" href="#appendix-a"></a></h2>
    <p>The following messages are defined with <a data-link-type="biblio" href="#biblio-cddl">[CDDL]</a>. When
 integer keys are used, a comment is appended to the line to indicate
-the name of the field. Each root message (one that can be put into a
+the name of the field. Object definitions in this specification have this
+unusual syntax to reduce the number of bytes-on-the-wire, while maintaining a
+human-readable name for each key. Integer keys are used instead of object arrays
+to allow for easy indexing of optional fields.</p>
+   <p>Each root message (one that can be put into a
 QUIC stream without being enclosed by another message) has a comment
 indicating the message type key.</p>
    <p>Smaller numbers should be reserved for message that will be sent more
@@ -3389,10 +3393,10 @@ because smaller type keys encode on the wire smaller.</p>
 })();
 </script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <aside class="dfn-panel" data-for="term-for-dom-window-postmessage">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-dom-window-postmessage-options">
+   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage-options">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage-options</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-window-postmessage">8.1.4. Same-Origin Policy Violations</a>
+    <li><a href="#ref-for-dom-window-postmessage-options">8.1.4. Same-Origin Policy Violations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-presentationconnection">
@@ -3501,7 +3505,7 @@ because smaller type keys encode on the wire smaller.</p>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-dom-window-postmessage" style="color:initial">postMessage(message, targetOrigin, transfer)</span>
+     <li><span class="dfn-paneled" id="term-for-dom-window-postmessage-options" style="color:initial">postMessage(message, options)</span>
     </ul>
    <li>
     <a data-link-type="biblio">[PRESENTATION-API]</a> defines the following terms:


### PR DESCRIPTION
Currently, we consistently use integer keys in our object
definitions, with the human readable field name appended as a comment.
This unusual syntax has significant memory benefits for us, but could
use an explanation for people not familiar with this design.