### PR TITLE
Authentication capabilities

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -409,6 +409,13 @@ the challenger.  This mechanism assumes the agents share a low-entropy secret,
 such as a number or a short password that could be entered by a user on a
 keyboard or TV remote control.
 
+Each supported authentication method is implemeted via authentication messages
+specific to that method. Authentication method is explicitly specified by
+the message itself. Authentication status message is common for all authentication
+methods. Any new authentication method added must define new authentication messages.
+Default authentication method is a challenge-response authentication with
+auth-request-hkdf-scrypt-psk and auth-response-hkdf-scrypt-psk-result.
+
 For all messages and objects defined in this section, see Appendix A for the full
 CDDL definitions.
 
@@ -465,16 +472,15 @@ For hkdf-of-scrypt-of-psk, the proof is calculated using the following steps:
 
 8. Let salt be the salt from the authentication-request message.
 
-9. Let info be a CBOR-serialized certificate-fingerprint-pair object (CDDL
-     defined in Appendix A) with the following values:
+9. Let info be a 64 byte array containing certificate fingerprint pair with the following values:
 
--   challenger-fingerprint: The result of running sha-256 on the
-    Distinguished Encoding Rules (DER) form (see
+-   Bytes 0-31 of the array are challenger fingerprint: The result of running
+    sha-256 on the Distinguished Encoding Rules (DER) form (see
     https://tools.ietf.org/html/rfc8122#section-5) of the certificate used by
     the challenger in the QUIC crypto handshake during connection establishment.
 
--   responder-fingerprint: The result of running sha-256 on the
-    Distinguished Encoding Rules (DER) form (see
+-   Bytes 32-63 of the array are responder fingerprint: The result of running
+    sha-256 on the Distinguished Encoding Rules (DER) form (see
     https://tools.ietf.org/html/rfc8122#section-5) of the certificate used by
     the responder in the QUIC crypto handshake during connection establishment.
 

--- a/index.bs
+++ b/index.bs
@@ -402,23 +402,23 @@ Authentication {#authentication}
 ================================
 
 Each supported authentication method is implemeted via authentication messages
-specific to that method.  Authentication method is explicitly specified by
-the message itself.  Authentication status message is common for all authentication
+specific to that method.  The authentication method is explicitly specified by
+the message itself.  The authentication status message is common for all authentication
 methods.  Any new authentication method added must define new authentication messages.
-Default authentication method is a challenge-response authentication with
+The default authentication method is a challenge-response authentication with
 auth-request-hkdf-scrypt-psk and auth-response-hkdf-scrypt-psk-result.
 
 Prior to authentication, agents exchange auth-capabilities messages specifying
-pre-shared key ease of input for the user and supported PSK input methods.
-The agent with the lowest PSK ease of input presents PSK to the user when the agent
+pre-shared key (PSK) ease of input for the user and supported PSK input methods.
+The agent with the lowest PSK ease of input presents a PSK to the user when the agent
 either sends or receives an authentication request.  In case both agents have the same
-PSK ease of input value, the receiver presents PSK to the user.  The same pre-shared key
+PSK ease of input value, the receiver presents the PSK to the user.  The same pre-shared key
 is used by both agents to issue an authentication request.
 
-PSK ease of input is an integer in [0, 100] range, where 0 means it is not possible for
-the user to input PSK on this device and 100 means that it's easy for the user to
-input PSK on the device.  Supported PSK input methods are numeric, alphanumeric and
-scanning a QR-code.
+PSK ease of input is an integer in [0, 100] inclusive range, where 0 means
+it is not possible for the user to input PSK on this device and 100 means
+that it's easy for the user to input PSK on the device.  Supported PSK input methods
+are numeric, alphanumeric and scanning a QR-code.
 
 In order for one agent (the challenger) to authenticate another (the responder),
 the challenger may send an authentication-request message and expect an
@@ -484,14 +484,14 @@ For hkdf-of-scrypt-of-psk, the proof is calculated using the following steps:
 
 8. Let salt be the salt from the authentication-request message.
 
-9. Let info be a 64 byte array containing certificate fingerprint pair with the following values:
+9. Let info be a 64-byte array containing certificate fingerprint pair with the following values:
 
--   Bytes 0-31 of the array are challenger fingerprint: The result of running
+-   Bytes 0-31 of the array are the challenger's fingerprint: The result of running
     sha-256 on the Distinguished Encoding Rules (DER) form (see
     https://tools.ietf.org/html/rfc8122#section-5) of the certificate used by
     the challenger in the QUIC crypto handshake during connection establishment.
 
--   Bytes 32-63 of the array are responder fingerprint: The result of running
+-   Bytes 32-63 of the array are the responder's fingerprint: The result of running
     sha-256 on the Distinguished Encoding Rules (DER) form (see
     https://tools.ietf.org/html/rfc8122#section-5) of the certificate used by
     the responder in the QUIC crypto handshake during connection establishment.

--- a/index.bs
+++ b/index.bs
@@ -401,6 +401,25 @@ Issue(139): Clarify scoping/uniqueness of request IDs.
 Authentication {#authentication}
 ================================
 
+Each supported authentication method is implemeted via authentication messages
+specific to that method.  Authentication method is explicitly specified by
+the message itself.  Authentication status message is common for all authentication
+methods.  Any new authentication method added must define new authentication messages.
+Default authentication method is a challenge-response authentication with
+auth-request-hkdf-scrypt-psk and auth-response-hkdf-scrypt-psk-result.
+
+Prior to authentication, agents exchange auth-capabilities messages specifying
+pre-shared key ease of input for the user and supported PSK input methods.
+The agent with the lowest PSK ease of input presents PSK to the user when the agent
+either sends or receives an authentication request.  In case both agents have the same
+PSK ease of input value, the receiver presents PSK to the user.  The same pre-shared key
+is used by both agents to issue an authentication request.
+
+PSK ease of input is an integer in [0, 100] range, where 0 means it is not possible for
+the user to input PSK on this device and 100 means that it's easy for the user to
+input PSK on the device. Supported PSK input methods are numeric, alphanumeric and
+scanning a QR-code.
+
 In order for one agent (the challenger) to authenticate another (the responder),
 the challenger may send an authentication-request message and expect an
 authentication-response message to be sent back from the responder.  To
@@ -408,13 +427,6 @@ mutually authenticate, this mechanism is used twice, once by each side acting as
 the challenger.  This mechanism assumes the agents share a low-entropy secret,
 such as a number or a short password that could be entered by a user on a
 keyboard or TV remote control.
-
-Each supported authentication method is implemeted via authentication messages
-specific to that method. Authentication method is explicitly specified by
-the message itself. Authentication status message is common for all authentication
-methods. Any new authentication method added must define new authentication messages.
-Default authentication method is a challenge-response authentication with
-auth-request-hkdf-scrypt-psk and auth-response-hkdf-scrypt-psk-result.
 
 For all messages and objects defined in this section, see Appendix A for the full
 CDDL definitions.
@@ -497,7 +509,6 @@ unauthenticated otherwise.
 Note: the values of 32 above (for salt length, keyLength) are based on the
 output size of sha-256.  If a different hash mechanism is used in the future,
 these values should be updated as well.
-
 
 Control Protocols {#control-protocols}
 ============================

--- a/index.bs
+++ b/index.bs
@@ -415,7 +415,7 @@ either sends or receives an authentication request.  In case both agents have th
 PSK ease of input value, the receiver presents the PSK to the user.  The same pre-shared key
 is used by both agents to issue an authentication request.
 
-PSK ease of input is an integer in [0, 100] inclusive range, where 0 means
+PSK ease of input is an integer in the range from 0 to 100 inclusive, where 0 means
 it is not possible for the user to input PSK on this device and 100 means
 that it's easy for the user to input PSK on the device.  Supported PSK input methods
 are numeric, alphanumeric and scanning a QR-code.

--- a/index.bs
+++ b/index.bs
@@ -417,7 +417,7 @@ is used by both agents to issue an authentication request.
 
 PSK ease of input is an integer in [0, 100] range, where 0 means it is not possible for
 the user to input PSK on this device and 100 means that it's easy for the user to
-input PSK on the device. Supported PSK input methods are numeric, alphanumeric and
+input PSK on the device.  Supported PSK input methods are numeric, alphanumeric and
 scanning a QR-code.
 
 In order for one agent (the challenger) to authenticate another (the responder),

--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 10ff3eb4050069e20bb9b943c8b76fe5bfe3a48f" name="generator">
+  <meta content="Bikeshed version ee4d7efc3ed6155392d49e10a542e2351fd5792d" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="93fe1e6b5ad8afba95b674b385c80aa2996252a5" name="document-revision">
+  <meta content="9c13420b0295475cf19c9c67f575a16c6b6e0fd2" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-05-10">10 May 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-05-13">13 May 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1855,6 +1855,22 @@ integer chosen by the requester.  Responses must include the request ID of the
 request they are associated with.</p>
    <p class="issue" id="issue-7a02cf11"><a class="self-link" href="#issue-7a02cf11"></a> Clarify scoping/uniqueness of request IDs. <a href="https://github.com/webscreens/openscreenprotocol/issues/139">&lt;https://github.com/webscreens/openscreenprotocol/issues/139></a></p>
    <h2 class="heading settled" data-level="6" id="authentication"><span class="secno">6. </span><span class="content">Authentication</span><a class="self-link" href="#authentication"></a></h2>
+   <p>Each supported authentication method is implemeted via authentication messages
+specific to that method.  Authentication method is explicitly specified by
+the message itself.  Authentication status message is common for all authentication
+methods.  Any new authentication method added must define new authentication messages.
+Default authentication method is a challenge-response authentication with
+auth-request-hkdf-scrypt-psk and auth-response-hkdf-scrypt-psk-result.</p>
+   <p>Prior to authentication, agents exchange auth-capabilities messages specifying
+pre-shared key ease of input for the user and supported PSK input methods.
+The agent with the lowest PSK ease of input presents PSK to the user when the agent
+either sends or receives an authentication request.  In case both agents have the same
+PSK ease of input value, the receiver presents PSK to the user.  The same pre-shared key
+is used by both agents to issue an authentication request.</p>
+   <p>PSK ease of input is an integer in [0, 100] range, where 0 means it is not possible for
+the user to input PSK on this device and 100 means that it’s easy for the user to
+input PSK on the device.  Supported PSK input methods are numeric, alphanumeric and
+scanning a QR-code.</p>
    <p>In order for one agent (the challenger) to authenticate another (the responder),
 the challenger may send an authentication-request message and expect an
 authentication-response message to be sent back from the responder.  To
@@ -1918,18 +1934,17 @@ seconds (to avoid the possibility of brute-force attacks.)</p>
     <li data-md>
      <p>Let salt be the salt from the authentication-request message.</p>
     <li data-md>
-     <p>Let info be a CBOR-serialized certificate-fingerprint-pair object (CDDL
- defined in Appendix A) with the following values:</p>
+     <p>Let info be a 64 byte array containing certificate fingerprint pair with the following values:</p>
    </ol>
    <ul>
     <li data-md>
-     <p>challenger-fingerprint: The result of running sha-256 on the
-Distinguished Encoding Rules (DER) form (see
+     <p>Bytes 0-31 of the array are challenger fingerprint: The result of running
+sha-256 on the Distinguished Encoding Rules (DER) form (see
 https://tools.ietf.org/html/rfc8122#section-5) of the certificate used by
 the challenger in the QUIC crypto handshake during connection establishment.</p>
     <li data-md>
-     <p>responder-fingerprint: The result of running sha-256 on the
-Distinguished Encoding Rules (DER) form (see
+     <p>Bytes 32-63 of the array are responder fingerprint: The result of running
+sha-256 on the Distinguished Encoding Rules (DER) form (see
 https://tools.ietf.org/html/rfc8122#section-5) of the certificate used by
 the responder in the QUIC crypto handshake during connection establishment.</p>
    </ul>
@@ -2892,11 +2907,6 @@ because smaller type keys encode on the wire smaller.</p>
   <span class="nx">cost-too-high</span><span class="p">:</span> <span class="mi">6</span>
 <span class="p">)</span></p>
 
-<p><span class="nx">certificate-fingerprint-pair </span><span class="p">=</span> <span class="p">[</span>
-  <span class="nx">challenger-fingerprint</span><span class="p">:</span> <span class="nx">bytes</span>
-<span class="nx">  responder-fingerprint</span><span class="p">:</span> <span class="nx">bytes</span>
-<span class="p">]</span></p>
-
 <p><span class="c1">; type key 1003</span>
 <span class="nx">auth-status </span><span class="p">=</span> <span class="p">{</span>
   <span class="mi">1</span> <span class="p">:</span> <span class="nx">auth-status-result </span><span class="c1">; result</span>
@@ -2909,6 +2919,18 @@ because smaller type keys encode on the wire smaller.</p>
   <span class="nx">secret-unknown</span><span class="p">:</span> <span class="mi">3</span>
   <span class="nx">validation-took-too-long </span><span class="p">:</span> <span class="mi">4</span>
   <span class="nx">proof-invalid</span><span class="p">:</span> <span class="mi">5</span>
+<span class="p">)</span></p>
+
+<p><span class="c1">; type key 1004</span>
+<span class="nx">auth-capabilities </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; psk-ease-of-input</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="p">[</span><span class="o">*</span> <span class="nx">psk-input-method</span><span class="p">]</span> <span class="c1">; psk-input-methods</span>
+<span class="p">}</span></p>
+
+<p><span class="nx">psk-input-method </span><span class="p">=</span> <span class="o">&amp;</span><span class="p">(</span>
+  <span class="nx">numeric</span><span class="p">:</span> <span class="mi">0</span>
+  <span class="nx">alphanumeric</span><span class="p">:</span> <span class="mi">1</span>
+  <span class="nx">qr-code</span><span class="p">:</span> <span class="mi">2</span>
 <span class="p">)</span></p>
 
 <p><span class="c1">; type key 14</span>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version ee4d7efc3ed6155392d49e10a542e2351fd5792d" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="dd949fc154505f97f124f680145e04bd3b671159" name="document-revision">
+  <meta content="5eca1d4af5bde9487e15314b0da665e23f2b1423" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1867,7 +1867,7 @@ The agent with the lowest PSK ease of input presents a PSK to the user when the 
 either sends or receives an authentication request.  In case both agents have the same
 PSK ease of input value, the receiver presents the PSK to the user.  The same pre-shared key
 is used by both agents to issue an authentication request.</p>
-   <p>PSK ease of input is an integer in [0, 100] inclusive range, where 0 means
+   <p>PSK ease of input is an integer in the range from 0 to 100 inclusive, where 0 means
 it is not possible for the user to input PSK on this device and 100 means
 that it’s easy for the user to input PSK on the device.  Supported PSK input methods
 are numeric, alphanumeric and scanning a QR-code.</p>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version ee4d7efc3ed6155392d49e10a542e2351fd5792d" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="9c13420b0295475cf19c9c67f575a16c6b6e0fd2" name="document-revision">
+  <meta content="dd949fc154505f97f124f680145e04bd3b671159" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1856,21 +1856,21 @@ request they are associated with.</p>
    <p class="issue" id="issue-7a02cf11"><a class="self-link" href="#issue-7a02cf11"></a> Clarify scoping/uniqueness of request IDs. <a href="https://github.com/webscreens/openscreenprotocol/issues/139">&lt;https://github.com/webscreens/openscreenprotocol/issues/139></a></p>
    <h2 class="heading settled" data-level="6" id="authentication"><span class="secno">6. </span><span class="content">Authentication</span><a class="self-link" href="#authentication"></a></h2>
    <p>Each supported authentication method is implemeted via authentication messages
-specific to that method.  Authentication method is explicitly specified by
-the message itself.  Authentication status message is common for all authentication
+specific to that method.  The authentication method is explicitly specified by
+the message itself.  The authentication status message is common for all authentication
 methods.  Any new authentication method added must define new authentication messages.
-Default authentication method is a challenge-response authentication with
+The default authentication method is a challenge-response authentication with
 auth-request-hkdf-scrypt-psk and auth-response-hkdf-scrypt-psk-result.</p>
    <p>Prior to authentication, agents exchange auth-capabilities messages specifying
-pre-shared key ease of input for the user and supported PSK input methods.
-The agent with the lowest PSK ease of input presents PSK to the user when the agent
+pre-shared key (PSK) ease of input for the user and supported PSK input methods.
+The agent with the lowest PSK ease of input presents a PSK to the user when the agent
 either sends or receives an authentication request.  In case both agents have the same
-PSK ease of input value, the receiver presents PSK to the user.  The same pre-shared key
+PSK ease of input value, the receiver presents the PSK to the user.  The same pre-shared key
 is used by both agents to issue an authentication request.</p>
-   <p>PSK ease of input is an integer in [0, 100] range, where 0 means it is not possible for
-the user to input PSK on this device and 100 means that it’s easy for the user to
-input PSK on the device.  Supported PSK input methods are numeric, alphanumeric and
-scanning a QR-code.</p>
+   <p>PSK ease of input is an integer in [0, 100] inclusive range, where 0 means
+it is not possible for the user to input PSK on this device and 100 means
+that it’s easy for the user to input PSK on the device.  Supported PSK input methods
+are numeric, alphanumeric and scanning a QR-code.</p>
    <p>In order for one agent (the challenger) to authenticate another (the responder),
 the challenger may send an authentication-request message and expect an
 authentication-response message to be sent back from the responder.  To
@@ -1934,16 +1934,16 @@ seconds (to avoid the possibility of brute-force attacks.)</p>
     <li data-md>
      <p>Let salt be the salt from the authentication-request message.</p>
     <li data-md>
-     <p>Let info be a 64 byte array containing certificate fingerprint pair with the following values:</p>
+     <p>Let info be a 64-byte array containing certificate fingerprint pair with the following values:</p>
    </ol>
    <ul>
     <li data-md>
-     <p>Bytes 0-31 of the array are challenger fingerprint: The result of running
+     <p>Bytes 0-31 of the array are the challenger’s fingerprint: The result of running
 sha-256 on the Distinguished Encoding Rules (DER) form (see
 https://tools.ietf.org/html/rfc8122#section-5) of the certificate used by
 the challenger in the QUIC crypto handshake during connection establishment.</p>
     <li data-md>
-     <p>Bytes 32-63 of the array are responder fingerprint: The result of running
+     <p>Bytes 32-63 of the array are the responder’s fingerprint: The result of running
 sha-256 on the Distinguished Encoding Rules (DER) form (see
 https://tools.ietf.org/html/rfc8122#section-5) of the certificate used by
 the responder in the QUIC crypto handshake during connection establishment.</p>

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -66,11 +66,6 @@ auth-response-hkdf-scrypt-psk-result = &(
   cost-too-high: 6
 )
 
-certificate-fingerprint-pair = [
-  challenger-fingerprint: bytes
-  responder-fingerprint: bytes
-]
-
 ; type key 1003
 auth-status = {
   1 : auth-status-result ; result

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -80,6 +80,18 @@ auth-status-result = &(
   proof-invalid: 5
 )
 
+; type key 1004
+auth-capabilities = {
+  0: uint ; psk-ease-of-input
+  1: [* psk-input-method] ; psk-input-methods
+}
+
+psk-input-method = &(
+  numeric: 0
+  alphanumeric: 1
+  qr-code: 2
+)
+
 ; type key 14
 presentation-url-availability-request = {
   request

--- a/messages_appendix.html
+++ b/messages_appendix.html
@@ -80,6 +80,18 @@
   <span class="nx">proof-invalid</span><span class="p">:</span> <span class="mi">5</span>
 <span class="p">)</span>
 
+<span class="c1">; type key 1004</span>
+<span class="nx">auth-capabilities </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; psk-ease-of-input</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="p">[</span><span class="o">*</span> <span class="nx">psk-input-method</span><span class="p">]</span> <span class="c1">; psk-input-methods</span>
+<span class="p">}</span>
+
+<span class="nx">psk-input-method </span><span class="p">=</span> <span class="o">&amp;</span><span class="p">(</span>
+  <span class="nx">numeric</span><span class="p">:</span> <span class="mi">0</span>
+  <span class="nx">alphanumeric</span><span class="p">:</span> <span class="mi">1</span>
+  <span class="nx">qr-code</span><span class="p">:</span> <span class="mi">2</span>
+<span class="p">)</span>
+
 <span class="c1">; type key 14</span>
 <span class="nx">presentation-url-availability-request </span><span class="p">=</span> <span class="p">{</span>
   <span class="nx">request</span>

--- a/messages_appendix.html
+++ b/messages_appendix.html
@@ -66,11 +66,6 @@
   <span class="nx">cost-too-high</span><span class="p">:</span> <span class="mi">6</span>
 <span class="p">)</span>
 
-<span class="nx">certificate-fingerprint-pair </span><span class="p">=</span> <span class="p">[</span>
-  <span class="nx">challenger-fingerprint</span><span class="p">:</span> <span class="nx">bytes</span>
-<span class="nx">  responder-fingerprint</span><span class="p">:</span> <span class="nx">bytes</span>
-<span class="p">]</span>
-
 <span class="c1">; type key 1003</span>
 <span class="nx">auth-status </span><span class="p">=</span> <span class="p">{</span>
   <span class="mi">1</span> <span class="p">:</span> <span class="nx">auth-status-result </span><span class="c1">; result</span>


### PR DESCRIPTION
Update authentication section with authentication capabilities for pre-shared key ease of input and PSK input methods.
Add clarification that each authentication method requires its own specific messages.
Add CDDL message for authentication capabilities.
Remove certificate-fingerprint-pair message and fix description of format used for HKDF info in the proposed default authentication method.