### PR TITLE
Authentication via J-PAKE

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -524,10 +524,11 @@ using auth-jpake-round1, auth-jpake-round2 and auth-jpake-confirmation messages,
 (see [[#appendix-a]] for message CDDL definitions).
 J-PAKE provides mutual authentication with  key confirmation step and is fully
 symmetric. Open Screen Protocol uses:
-1. SHA-256 as hash function
-2. HMAC with SHA-256 as MAC function
-3. HKDF with SHA-256 as KDF function
-4. The second key confirmation method described in https://tools.ietf.org/html/rfc8236#section-5
+1. J-PAKE over elliptic curve described in https://tools.ietf.org/html/rfc8236#section-3
+2. SHA-256 as hash function
+3. HMAC with SHA-256 as MAC function
+4. HKDF with SHA-256 as KDF function
+5. The second key confirmation method described in https://tools.ietf.org/html/rfc8236#section-5
 
 An agent may send auth-jpake-round1 message at any time to start
 the authentication process with the other agent.

--- a/index.bs
+++ b/index.bs
@@ -516,6 +516,50 @@ Note: the values of 32 above (for salt length, keyLength) are based on the
 output size of sha-256.  If a different hash mechanism is used in the future,
 these values should be updated as well.
 
+Authentication via J-PAKE {#authentication-jpake}
+================================
+
+Authentication via J-PAKE protocol (https://tools.ietf.org/html/rfc8236) is
+using auth-jpake-round1, auth-jpake-round2 and auth-jpake-confirmation messages,
+(see [[#appendix-a]] for message CDDL definitions).
+J-PAKE provides mutual authentication with  key confirmation step and is fully
+symmetric. Open Screen Protocol uses:
+1. SHA-256 as hash function
+2. HMAC with SHA-256 as MAC function
+3. HKDF with SHA-256 as KDF function
+4. The second key confirmation method described in https://tools.ietf.org/html/rfc8236#section-5
+
+An agent may send auth-jpake-round1 message at any time to start
+the authentication process with the other agent.
+
+After sending auth-jpake-round1, the agent expects to receive auth-jpake-round1
+and auth-jpake-round2 messages.
+
+After receiving auth-jpake-round1 message, the agent validates the message and, if
+the validation passes, sends:
+1. auth-jpake-round1 message, in case the agent has not sent it yet;
+2. auth-jpake-round2 message.
+
+After sending auth-jpake-round2, the agent expects to receive
+auth-jpake-confirmation message.
+
+After receiving auth-jpake-round2 message, the agent validates the message and,
+if the validation passes and the agent has received auth-jpake-round1 message
+as well, the agent sends auth-jpake-confirmation message.
+
+After receiving auth-jpake-confirmation message, the agent verifies MAC to confirm
+that both agents have derived the same key.
+
+At this point the authentication is complete, the agent sends auth-status
+with success code.
+
+The agents use auth-capabilities to determine which agent presents
+the pre-shared key (PSK) to the user as described in [[#authentication]].
+The agent presenting the PSK to the user does so either when the agent sends or receives
+auth-jpake-round1 message.  The agent prompting the user for the PSK input does so either
+when the agent sends or receives auth-jpake-round1 message.  The PSK is required for
+computation used in producing and validating auth-jpake2-round2 message.
+
 Control Protocols {#control-protocols}
 ============================
 

--- a/index.bs
+++ b/index.bs
@@ -525,10 +525,11 @@ using auth-jpake-round1, auth-jpake-round2 and auth-jpake-confirmation messages,
 J-PAKE provides mutual authentication with  key confirmation step and is fully
 symmetric. Open Screen Protocol uses:
 1. J-PAKE over elliptic curve described in https://tools.ietf.org/html/rfc8236#section-3
-2. SHA-256 as hash function
-3. HMAC with SHA-256 as MAC function
-4. HKDF with SHA-256 as KDF function
-5. The second key confirmation method described in https://tools.ietf.org/html/rfc8236#section-5
+2. Curve25519 as elliptic curve
+3. SHA-256 as hash function
+4. HMAC with SHA-256 as MAC function
+5. HKDF with SHA-256 as KDF function
+6. The second key confirmation method described in https://tools.ietf.org/html/rfc8236#section-5
 
 An agent may send auth-jpake-round1 message at any time to start
 the authentication process with the other agent.

--- a/index.bs
+++ b/index.bs
@@ -531,26 +531,26 @@ symmetric. Open Screen Protocol uses:
 5. HKDF with SHA-256 as KDF function
 6. The second key confirmation method described in https://tools.ietf.org/html/rfc8236#section-5
 
-An agent may send auth-jpake-round1 message at any time to start
+An agent may send a auth-jpake-round1 message at any time to start
 the authentication process with the other agent.
 
-After sending auth-jpake-round1, the agent expects to receive auth-jpake-round1
+After sending the auth-jpake-round1 message, the agent expects to receive auth-jpake-round1
 and auth-jpake-round2 messages.
 
-After receiving auth-jpake-round1 message, the agent validates the message and, if
+After receiving a auth-jpake-round1 message, the agent validates the message and, if
 the validation passes, sends:
-1. auth-jpake-round1 message, in case the agent has not sent it yet;
-2. auth-jpake-round2 message.
+1. a auth-jpake-round1 message, in case the agent has not sent it yet;
+2. a auth-jpake-round2 message.
 
-After sending auth-jpake-round2, the agent expects to receive
-auth-jpake-confirmation message.
+After sending the auth-jpake-round2 message, the agent expects to receive
+a auth-jpake-confirmation message.
 
-After receiving auth-jpake-round2 message, the agent validates the message and,
-if the validation passes and the agent has received auth-jpake-round1 message
-as well, the agent sends auth-jpake-confirmation message.
+After receiving a auth-jpake-round2 message, the agent validates the message and,
+if the validation passes and the agent has received the auth-jpake-round1 message
+as well, the agent sends a auth-jpake-confirmation message.
 
-After receiving auth-jpake-confirmation message, the agent verifies MAC to confirm
-that both agents have derived the same key.
+After receiving the auth-jpake-confirmation message, the agent verifies
+the MAC to confirm that both agents have derived the same key.
 
 At this point the authentication is complete, the agent sends auth-status
 with success code.

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version ee4d7efc3ed6155392d49e10a542e2351fd5792d" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="b16482b7f9800726af5595ff53b9ecdfbc0e57ab" name="document-revision">
+  <meta content="9f2dee8f70368d1fde43b12ac37442617aa90013" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-05-14">14 May 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-05-20">20 May 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1996,25 +1996,25 @@ symmetric. Open Screen Protocol uses:</p>
     <li data-md>
      <p>The second key confirmation method described in https://tools.ietf.org/html/rfc8236#section-5</p>
    </ol>
-   <p>An agent may send auth-jpake-round1 message at any time to start
+   <p>An agent may send a auth-jpake-round1 message at any time to start
 the authentication process with the other agent.</p>
-   <p>After sending auth-jpake-round1, the agent expects to receive auth-jpake-round1
+   <p>After sending the auth-jpake-round1 message, the agent expects to receive auth-jpake-round1
 and auth-jpake-round2 messages.</p>
-   <p>After receiving auth-jpake-round1 message, the agent validates the message and, if
+   <p>After receiving a auth-jpake-round1 message, the agent validates the message and, if
 the validation passes, sends:</p>
    <ol>
     <li data-md>
-     <p>auth-jpake-round1 message, in case the agent has not sent it yet;</p>
+     <p>a auth-jpake-round1 message, in case the agent has not sent it yet;</p>
     <li data-md>
-     <p>auth-jpake-round2 message.</p>
+     <p>a auth-jpake-round2 message.</p>
    </ol>
-   <p>After sending auth-jpake-round2, the agent expects to receive
-auth-jpake-confirmation message.</p>
-   <p>After receiving auth-jpake-round2 message, the agent validates the message and,
-if the validation passes and the agent has received auth-jpake-round1 message
-as well, the agent sends auth-jpake-confirmation message.</p>
-   <p>After receiving auth-jpake-confirmation message, the agent verifies MAC to confirm
-that both agents have derived the same key.</p>
+   <p>After sending the auth-jpake-round2 message, the agent expects to receive
+a auth-jpake-confirmation message.</p>
+   <p>After receiving a auth-jpake-round2 message, the agent validates the message and,
+if the validation passes and the agent has received the auth-jpake-round1 message
+as well, the agent sends a auth-jpake-confirmation message.</p>
+   <p>After receiving the auth-jpake-confirmation message, the agent verifies
+the MAC to confirm that both agents have derived the same key.</p>
    <p>At this point the authentication is complete, the agent sends auth-status
 with success code.</p>
    <p>The agents use auth-capabilities to determine which agent presents

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version ee4d7efc3ed6155392d49e10a542e2351fd5792d" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="10ec16f0c25e8df58c6bc2f383808c3b08f4242e" name="document-revision">
+  <meta content="d00b7f7db1d029e49d9bff958c34deafac7eca51" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1983,6 +1983,8 @@ using auth-jpake-round1, auth-jpake-round2 and auth-jpake-confirmation messages,
 J-PAKE provides mutual authentication with  key confirmation step and is fully
 symmetric. Open Screen Protocol uses:</p>
    <ol>
+    <li data-md>
+     <p>J-PAKE over elliptic curve described in https://tools.ietf.org/html/rfc8236#section-3</p>
     <li data-md>
      <p>SHA-256 as hash function</p>
     <li data-md>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version ee4d7efc3ed6155392d49e10a542e2351fd5792d" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="d00b7f7db1d029e49d9bff958c34deafac7eca51" name="document-revision">
+  <meta content="b16482b7f9800726af5595ff53b9ecdfbc0e57ab" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1985,6 +1985,8 @@ symmetric. Open Screen Protocol uses:</p>
    <ol>
     <li data-md>
      <p>J-PAKE over elliptic curve described in https://tools.ietf.org/html/rfc8236#section-3</p>
+    <li data-md>
+     <p>Curve25519 as elliptic curve</p>
     <li data-md>
      <p>SHA-256 as hash function</p>
     <li data-md>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version ee4d7efc3ed6155392d49e10a542e2351fd5792d" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="0580952ce4d0b4aeeb7282a8673e76d267c314e9" name="document-revision">
+  <meta content="10ec16f0c25e8df58c6bc2f383808c3b08f4242e" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-05-13">13 May 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-05-14">14 May 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1513,57 +1513,58 @@ pre .property::before, pre .property::after {
     <li><a href="#transport"><span class="secno">4</span> <span class="content">Transport and metadata discovery with QUIC</span></a>
     <li><a href="#messages"><span class="secno">5</span> <span class="content">Messages delivery using CBOR and QUIC streams</span></a>
     <li><a href="#authentication"><span class="secno">6</span> <span class="content">Authentication</span></a>
+    <li><a href="#authentication-jpake"><span class="secno">7</span> <span class="content">Authentication via J-PAKE</span></a>
     <li>
-     <a href="#control-protocols"><span class="secno">7</span> <span class="content">Control Protocols</span></a>
+     <a href="#control-protocols"><span class="secno">8</span> <span class="content">Control Protocols</span></a>
      <ol class="toc">
-      <li><a href="#presentation-protocol"><span class="secno">7.1</span> <span class="content">Presentation Protocol</span></a>
-      <li><a href="#presentation-api"><span class="secno">7.2</span> <span class="content">Presentation API</span></a>
-      <li><a href="#remote-playback-protocol"><span class="secno">7.3</span> <span class="content">Remote Playback Protocol</span></a>
-      <li><a href="#remote-playback-state-and-controls"><span class="secno">7.4</span> <span class="content">Remote Playback State and Controls</span></a>
-      <li><a href="#remote-playback-api"><span class="secno">7.5</span> <span class="content">Remote Playback API</span></a>
+      <li><a href="#presentation-protocol"><span class="secno">8.1</span> <span class="content">Presentation Protocol</span></a>
+      <li><a href="#presentation-api"><span class="secno">8.2</span> <span class="content">Presentation API</span></a>
+      <li><a href="#remote-playback-protocol"><span class="secno">8.3</span> <span class="content">Remote Playback Protocol</span></a>
+      <li><a href="#remote-playback-state-and-controls"><span class="secno">8.4</span> <span class="content">Remote Playback State and Controls</span></a>
+      <li><a href="#remote-playback-api"><span class="secno">8.5</span> <span class="content">Remote Playback API</span></a>
      </ol>
     <li>
-     <a href="#streaming-protocol"><span class="secno">8</span> <span class="content">Streaming Protocol</span></a>
+     <a href="#streaming-protocol"><span class="secno">9</span> <span class="content">Streaming Protocol</span></a>
      <ol class="toc">
-      <li><a href="#streaming-capabilities"><span class="secno">8.1</span> <span class="content">Capabilities</span></a>
-      <li><a href="#streaming-sessions"><span class="secno">8.2</span> <span class="content">Sessions</span></a>
-      <li><a href="#streaming-audio"><span class="secno">8.3</span> <span class="content">Audio</span></a>
-      <li><a href="#streaming-video"><span class="secno">8.4</span> <span class="content">Video</span></a>
-      <li><a href="#media-streaming-data"><span class="secno">8.5</span> <span class="content">Data</span></a>
-      <li><a href="#streaming-feedback"><span class="secno">8.6</span> <span class="content">Feedback</span></a>
-      <li><a href="#streaming-stats"><span class="secno">8.7</span> <span class="content">Stats</span></a>
+      <li><a href="#streaming-capabilities"><span class="secno">9.1</span> <span class="content">Capabilities</span></a>
+      <li><a href="#streaming-sessions"><span class="secno">9.2</span> <span class="content">Sessions</span></a>
+      <li><a href="#streaming-audio"><span class="secno">9.3</span> <span class="content">Audio</span></a>
+      <li><a href="#streaming-video"><span class="secno">9.4</span> <span class="content">Video</span></a>
+      <li><a href="#media-streaming-data"><span class="secno">9.5</span> <span class="content">Data</span></a>
+      <li><a href="#streaming-feedback"><span class="secno">9.6</span> <span class="content">Feedback</span></a>
+      <li><a href="#streaming-stats"><span class="secno">9.7</span> <span class="content">Stats</span></a>
      </ol>
     <li>
-     <a href="#security-privacy"><span class="secno">9</span> <span class="content">Security and Privacy</span></a>
+     <a href="#security-privacy"><span class="secno">10</span> <span class="content">Security and Privacy</span></a>
      <ol class="toc">
       <li>
-       <a href="#threat-models"><span class="secno">9.1</span> <span class="content">Threat Models</span></a>
+       <a href="#threat-models"><span class="secno">10.1</span> <span class="content">Threat Models</span></a>
        <ol class="toc">
-        <li><a href="#passive-network-attackers"><span class="secno">9.1.1</span> <span class="content">Passive Network Attackers</span></a>
-        <li><a href="#active-network-attackers"><span class="secno">9.1.2</span> <span class="content">Active Network Attackers</span></a>
-        <li><a href="#denial-of-service"><span class="secno">9.1.3</span> <span class="content">Denial of Service</span></a>
-        <li><a href="#same-origin-policy-violations"><span class="secno">9.1.4</span> <span class="content">Same-Origin Policy Violations</span></a>
+        <li><a href="#passive-network-attackers"><span class="secno">10.1.1</span> <span class="content">Passive Network Attackers</span></a>
+        <li><a href="#active-network-attackers"><span class="secno">10.1.2</span> <span class="content">Active Network Attackers</span></a>
+        <li><a href="#denial-of-service"><span class="secno">10.1.3</span> <span class="content">Denial of Service</span></a>
+        <li><a href="#same-origin-policy-violations"><span class="secno">10.1.4</span> <span class="content">Same-Origin Policy Violations</span></a>
        </ol>
       <li>
-       <a href="#security-privacy-questions"><span class="secno">9.2</span> <span class="content">Open Screen Protocol Security and Privacy Considerations</span></a>
+       <a href="#security-privacy-questions"><span class="secno">10.2</span> <span class="content">Open Screen Protocol Security and Privacy Considerations</span></a>
        <ol class="toc">
-        <li><a href="#personally-identifiable-information"><span class="secno">9.2.1</span> <span class="content">Personally Identifiable Information &amp; High-Value Data</span></a>
-        <li><a href="#cross-origin-state"><span class="secno">9.2.2</span> <span class="content">Cross Origin State Considerations</span></a>
-        <li><a href="#origin-access-devices"><span class="secno">9.2.3</span> <span class="content">Origin Access to Other Devices</span></a>
-        <li><a href="#incognito-mode"><span class="secno">9.2.4</span> <span class="content">Incognito Mode</span></a>
-        <li><a href="#persistent-state"><span class="secno">9.2.5</span> <span class="content">Persistent State</span></a>
-        <li><a href="#other-considerations"><span class="secno">9.2.6</span> <span class="content">Other Considerations</span></a>
+        <li><a href="#personally-identifiable-information"><span class="secno">10.2.1</span> <span class="content">Personally Identifiable Information &amp; High-Value Data</span></a>
+        <li><a href="#cross-origin-state"><span class="secno">10.2.2</span> <span class="content">Cross Origin State Considerations</span></a>
+        <li><a href="#origin-access-devices"><span class="secno">10.2.3</span> <span class="content">Origin Access to Other Devices</span></a>
+        <li><a href="#incognito-mode"><span class="secno">10.2.4</span> <span class="content">Incognito Mode</span></a>
+        <li><a href="#persistent-state"><span class="secno">10.2.5</span> <span class="content">Persistent State</span></a>
+        <li><a href="#other-considerations"><span class="secno">10.2.6</span> <span class="content">Other Considerations</span></a>
        </ol>
-      <li><a href="#presentation-api-considerations"><span class="secno">9.3</span> <span class="content">Presentation API Considerations</span></a>
-      <li><a href="#remote-playback-considerations"><span class="secno">9.4</span> <span class="content">Remote Playback API Considerations</span></a>
+      <li><a href="#presentation-api-considerations"><span class="secno">10.3</span> <span class="content">Presentation API Considerations</span></a>
+      <li><a href="#remote-playback-considerations"><span class="secno">10.4</span> <span class="content">Remote Playback API Considerations</span></a>
       <li>
-       <a href="#security-mitigations"><span class="secno">9.5</span> <span class="content">Mitigation Strategies</span></a>
+       <a href="#security-mitigations"><span class="secno">10.5</span> <span class="content">Mitigation Strategies</span></a>
        <ol class="toc">
-        <li><a href="#local-passive-mitigations"><span class="secno">9.5.1</span> <span class="content">Local passive network attackers</span></a>
-        <li><a href="#local-active-mitigations"><span class="secno">9.5.2</span> <span class="content">Local active network attackers</span></a>
-        <li><a href="#remote-active-mitigations"><span class="secno">9.5.3</span> <span class="content">Remote active network attackers</span></a>
-        <li><a href="#denial-of-service-mitigations"><span class="secno">9.5.4</span> <span class="content">Denial of service</span></a>
-        <li><a href="#malicious-input-mitigations"><span class="secno">9.5.5</span> <span class="content">Malicious input</span></a>
+        <li><a href="#local-passive-mitigations"><span class="secno">10.5.1</span> <span class="content">Local passive network attackers</span></a>
+        <li><a href="#local-active-mitigations"><span class="secno">10.5.2</span> <span class="content">Local active network attackers</span></a>
+        <li><a href="#remote-active-mitigations"><span class="secno">10.5.3</span> <span class="content">Remote active network attackers</span></a>
+        <li><a href="#denial-of-service-mitigations"><span class="secno">10.5.4</span> <span class="content">Denial of service</span></a>
+        <li><a href="#malicious-input-mitigations"><span class="secno">10.5.5</span> <span class="content">Malicious input</span></a>
        </ol>
      </ol>
     <li><a href="#appendix-a"><span class="secno"></span> <span class="content">Appendix A: Messages</span></a>
@@ -1975,10 +1976,53 @@ unauthenticated otherwise.</p>
    <p class="note" role="note"><span>Note:</span> the values of 32 above (for salt length, keyLength) are based on the
 output size of sha-256.  If a different hash mechanism is used in the future,
 these values should be updated as well.</p>
-   <h2 class="heading settled" data-level="7" id="control-protocols"><span class="secno">7. </span><span class="content">Control Protocols</span><a class="self-link" href="#control-protocols"></a></h2>
-   <h3 class="heading settled" data-level="7.1" id="presentation-protocol"><span class="secno">7.1. </span><span class="content">Presentation Protocol</span><a class="self-link" href="#presentation-protocol"></a></h3>
+   <h2 class="heading settled" data-level="7" id="authentication-jpake"><span class="secno">7. </span><span class="content">Authentication via J-PAKE</span><a class="self-link" href="#authentication-jpake"></a></h2>
+   <p>Authentication via J-PAKE protocol (https://tools.ietf.org/html/rfc8236) is
+using auth-jpake-round1, auth-jpake-round2 and auth-jpake-confirmation messages,
+(see <a href="#appendix-a">Appendix A: Messages</a> for message CDDL definitions).
+J-PAKE provides mutual authentication with  key confirmation step and is fully
+symmetric. Open Screen Protocol uses:</p>
+   <ol>
+    <li data-md>
+     <p>SHA-256 as hash function</p>
+    <li data-md>
+     <p>HMAC with SHA-256 as MAC function</p>
+    <li data-md>
+     <p>HKDF with SHA-256 as KDF function</p>
+    <li data-md>
+     <p>The second key confirmation method described in https://tools.ietf.org/html/rfc8236#section-5</p>
+   </ol>
+   <p>An agent may send auth-jpake-round1 message at any time to start
+the authentication process with the other agent.</p>
+   <p>After sending auth-jpake-round1, the agent expects to receive auth-jpake-round1
+and auth-jpake-round2 messages.</p>
+   <p>After receiving auth-jpake-round1 message, the agent validates the message and, if
+the validation passes, sends:</p>
+   <ol>
+    <li data-md>
+     <p>auth-jpake-round1 message, in case the agent has not sent it yet;</p>
+    <li data-md>
+     <p>auth-jpake-round2 message.</p>
+   </ol>
+   <p>After sending auth-jpake-round2, the agent expects to receive
+auth-jpake-confirmation message.</p>
+   <p>After receiving auth-jpake-round2 message, the agent validates the message and,
+if the validation passes and the agent has received auth-jpake-round1 message
+as well, the agent sends auth-jpake-confirmation message.</p>
+   <p>After receiving auth-jpake-confirmation message, the agent verifies MAC to confirm
+that both agents have derived the same key.</p>
+   <p>At this point the authentication is complete, the agent sends auth-status
+with success code.</p>
+   <p>The agents use auth-capabilities to determine which agent presents
+the pre-shared key (PSK) to the user as described in <a href="#authentication">§6 Authentication</a>.
+The agent presenting the PSK to the user does so either when the agent sends or receives
+auth-jpake-round1 message.  The agent prompting the user for the PSK input does so either
+when the agent sends or receives auth-jpake-round1 message.  The PSK is required for
+computation used in producing and validating auth-jpake2-round2 message.</p>
+   <h2 class="heading settled" data-level="8" id="control-protocols"><span class="secno">8. </span><span class="content">Control Protocols</span><a class="self-link" href="#control-protocols"></a></h2>
+   <h3 class="heading settled" data-level="8.1" id="presentation-protocol"><span class="secno">8.1. </span><span class="content">Presentation Protocol</span><a class="self-link" href="#presentation-protocol"></a></h3>
    <p>This section defines the use of the Open Screen Protocol for starting,
-terminating, and controlling presentations as defined by <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a>. <a href="#presentation-api">§7.2 Presentation API</a> defines how APIs in <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> map to the
+terminating, and controlling presentations as defined by <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a>. <a href="#presentation-api">§8.2 Presentation API</a> defines how APIs in <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> map to the
 protocol messages defined in this section.</p>
    <p>For all messages defined in this section, see <a href="#appendix-a">Appendix A: Messages</a> for the full
 CDDL definitions.</p>
@@ -2163,8 +2207,8 @@ values:</p>
      <p>A debug message suitable for a log or perhaps presented to
 the user with more explanation as to why it was closed.</p>
    </dl>
-   <h3 class="heading settled" data-level="7.2" id="presentation-api"><span class="secno">7.2. </span><span class="content">Presentation API</span><a class="self-link" href="#presentation-api"></a></h3>
-   <p>This section defines how the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> uses the <a href="#presentation-protocol">§7.1 Presentation Protocol</a>.</p>
+   <h3 class="heading settled" data-level="8.2" id="presentation-api"><span class="secno">8.2. </span><span class="content">Presentation API</span><a class="self-link" href="#presentation-api"></a></h3>
+   <p>This section defines how the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> uses the <a href="#presentation-protocol">§8.1 Presentation Protocol</a>.</p>
    <p>When <a href="https://www.w3.org/TR/presentation-api/#the-list-of-available-presentation-displays">section
 6.4.2</a> says "This list of presentation displays ... is populated based on an
 implementation specific discovery mechanism", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent" id="ref-for-dfn-controlling-user-agent②">controlling user agent</a> may
@@ -2202,9 +2246,9 @@ presentation-connection-open-request.</p>
 6.7.1</a> says "Establish the connection between the controlling and receiving
 browsing contexts using an implementation specific mechanism.", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent" id="ref-for-dfn-receiving-user-agent②">receiving
 user agent</a>, must send a presentation-connection-open-response message.</p>
-   <h3 class="heading settled" data-level="7.3" id="remote-playback-protocol"><span class="secno">7.3. </span><span class="content">Remote Playback Protocol</span><a class="self-link" href="#remote-playback-protocol"></a></h3>
+   <h3 class="heading settled" data-level="8.3" id="remote-playback-protocol"><span class="secno">8.3. </span><span class="content">Remote Playback Protocol</span><a class="self-link" href="#remote-playback-protocol"></a></h3>
    <p>This section defines the use of the Open Screen Protocol for starting, terminating,
-and controlling remote playback of media as defined by the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a>. <a href="#remote-playback-api">§7.5 Remote Playback API</a> defines how
+and controlling remote playback of media as defined by the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a>. <a href="#remote-playback-api">§8.5 Remote Playback API</a> defines how
 APIs in <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> map to the protocol messages
 defined in this section.</p>
    <p>For all messages defined in this section, see Appendix A for the full
@@ -2292,7 +2336,7 @@ receiver.</p>
     <dt data-md>controls
     <dd data-md>
      <p>Initial controls for modifying the initial state of the remote playback, as
-defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.  The controller may send
+defined in <a href="#remote-playback-state-and-controls">§8.4 Remote Playback State and Controls</a>.  The controller may send
 controls that are optional for the receiver to support before it knows the
 receiver supports them.  If the receiver does not support them, it will
 ignore them and the controller will learn that it does not support them from
@@ -2309,7 +2353,7 @@ invalid-url).  Additionally, the response must include the following:</p>
    <dl>
     <dt data-md>state
     <dd data-md>
-     <p>The initial state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.</p>
+     <p>The initial state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§8.4 Remote Playback State and Controls</a>.</p>
    </dl>
    <p>If the controller wishes to modify the state of the remote playback (for
 example, to pause, resume, skip, etc), it may send a
@@ -2327,7 +2371,7 @@ remote-playback-modify-response message in reply with the following values:</p>
    <dl>
     <dt data-md>state
     <dd data-md>
-     <p>The updated state of the remote playback as defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.</p>
+     <p>The updated state of the remote playback as defined in <a href="#remote-playback-state-and-controls">§8.4 Remote Playback State and Controls</a>.</p>
    </dl>
    <p>When the state of remote playback changes without request for modification from
 the controller (such as when the skips or pauses due to user user interaction on
@@ -2339,7 +2383,7 @@ controller.</p>
      <p>The ID of the remote playback whose state has changed.</p>
     <dt data-md>state
     <dd data-md>
-     <p>The updated state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.</p>
+     <p>The updated state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§8.4 Remote Playback State and Controls</a>.</p>
    </dl>
    <p>To terminate the remote playback, the controller may send a
 remote-playback-termination-request message with the following values:</p>
@@ -2369,7 +2413,7 @@ API section 6.2.7</a>, terminating the remote playback means the controller is n
 longer controlling the remote playback and does not necessarily stop media from
 rendering on the receiver.  Whether or not the receiver stops rendering media depends
 upon the implementation of the receiver.</p>
-   <h3 class="heading settled" data-level="7.4" id="remote-playback-state-and-controls"><span class="secno">7.4. </span><span class="content">Remote Playback State and Controls</span><a class="self-link" href="#remote-playback-state-and-controls"></a></h3>
+   <h3 class="heading settled" data-level="8.4" id="remote-playback-state-and-controls"><span class="secno">8.4. </span><span class="content">Remote Playback State and Controls</span><a class="self-link" href="#remote-playback-state-and-controls"></a></h3>
    <p>In order for the controller and receiver to stay in sync with regards to the
 state of the remote playback, the controller may send controls to modify the state
 (for example, via the remote-playback-modify-request message) and the receiver
@@ -2558,9 +2602,9 @@ seekable-time-ranges) used above use a common media-time value (see Appendix A)
 which includes a time scale.  This allows time values which work on different
 time scales to be expressed without loss of precision.  The scale is represented
 in hertz, such as 90000 for 90000hz, a common time scale for video.</p>
-   <h3 class="heading settled" data-level="7.5" id="remote-playback-api"><span class="secno">7.5. </span><span class="content">Remote Playback API</span><a class="self-link" href="#remote-playback-api"></a></h3>
+   <h3 class="heading settled" data-level="8.5" id="remote-playback-api"><span class="secno">8.5. </span><span class="content">Remote Playback API</span><a class="self-link" href="#remote-playback-api"></a></h3>
    <p>This section defines how the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> uses the
-messages defined in <a href="#remote-playback-protocol">§7.3 Remote Playback Protocol</a>.</p>
+messages defined in <a href="#remote-playback-protocol">§8.3 Remote Playback Protocol</a>.</p>
    <p>When <a href="https://www.w3.org/TR/remote-playback/#the-list-of-available-remote-playback-devices">section
 6.2.1.2</a> says "This list contains remote playback devices and is populated
 based on an implementation specific discovery mechanism" and <a href="https://www.w3.org/TR/remote-playback/#the-list-of-available-remote-playback-devices">section
@@ -2593,10 +2637,10 @@ change the local media element based on changes to the remote playback state.</p
 6.2.7</a> says "Request disconnection of remote from the device. The
 implementation of this step is specific to the user agent.", the controlling
 user agent may send the remote-playback-termination-request message.</p>
-   <h2 class="heading settled" data-level="8" id="streaming-protocol"><span class="secno">8. </span><span class="content">Streaming Protocol</span><a class="self-link" href="#streaming-protocol"></a></h2>
+   <h2 class="heading settled" data-level="9" id="streaming-protocol"><span class="secno">9. </span><span class="content">Streaming Protocol</span><a class="self-link" href="#streaming-protocol"></a></h2>
    <p>This section defines the use of the Open Screen Protocol for streaming
 media from a media sender to a media receiver.</p>
-   <h3 class="heading settled" data-level="8.1" id="streaming-capabilities"><span class="secno">8.1. </span><span class="content">Capabilities</span><a class="self-link" href="#streaming-capabilities"></a></h3>
+   <h3 class="heading settled" data-level="9.1" id="streaming-capabilities"><span class="secno">9.1. </span><span class="content">Capabilities</span><a class="self-link" href="#streaming-capabilities"></a></h3>
     If the advertiser is already authenticated, the requester has the ability to
 request additional information by sending an streaming-capabilities-request
 message, and receive back a streaming-capabilities-response message with the
@@ -2678,9 +2722,9 @@ The default value is none.</p>
 provided in a video-resolution not listed in the native-resolutions list
 (if provided) or of a different aspect ratio. The default value is true.</p>
    </dl>
-   <h3 class="heading settled" data-level="8.2" id="streaming-sessions"><span class="secno">8.2. </span><span class="content">Sessions</span><a class="self-link" href="#streaming-sessions"></a></h3>
+   <h3 class="heading settled" data-level="9.2" id="streaming-sessions"><span class="secno">9.2. </span><span class="content">Sessions</span><a class="self-link" href="#streaming-sessions"></a></h3>
    <p>TODO</p>
-   <h3 class="heading settled" data-level="8.3" id="streaming-audio"><span class="secno">8.3. </span><span class="content">Audio</span><a class="self-link" href="#streaming-audio"></a></h3>
+   <h3 class="heading settled" data-level="9.3" id="streaming-audio"><span class="secno">9.3. </span><span class="content">Audio</span><a class="self-link" href="#streaming-audio"></a></h3>
    <p>Senders may send audio to receivers by sending audio-frame messages (see <a href="#appendix-a">Appendix A: Messages</a>) with the following keys and values.  An audio frame message
 contains a set of encoded audio samples for a range of time. A series of
 encoded audio frames that share a codec, codec parameters and a timeline form an
@@ -2729,7 +2773,7 @@ be; it can be any clock chosen by the sender.</p>
     <dd data-md>
      <p>The data.  The type of data is inferred from the properties of the encoding.</p>
    </dl>
-   <h3 class="heading settled" data-level="8.4" id="streaming-video"><span class="secno">8.4. </span><span class="content">Video</span><a class="self-link" href="#streaming-video"></a></h3>
+   <h3 class="heading settled" data-level="9.4" id="streaming-video"><span class="secno">9.4. </span><span class="content">Video</span><a class="self-link" href="#streaming-video"></a></h3>
    <p>Senders may send video to receivers by sending video-frame messages (see <a href="#appendix-a">Appendix A: Messages</a>) with the following keys and values.  A video frame message
 contains an encoded video frame (an encoded image) at a specific point in time
 or over a specfic time range (if the duration is known).  A series of encoded
@@ -2786,7 +2830,7 @@ The default is 0 (no rotation).</p>
      <p>The encoded video frame (encoded image).  The codec and codec parameters are
 inferred from the properties of the encoding.</p>
    </dl>
-   <h3 class="heading settled" data-level="8.5" id="media-streaming-data"><span class="secno">8.5. </span><span class="content">Data</span><a class="self-link" href="#media-streaming-data"></a></h3>
+   <h3 class="heading settled" data-level="9.5" id="media-streaming-data"><span class="secno">9.5. </span><span class="content">Data</span><a class="self-link" href="#media-streaming-data"></a></h3>
    <p>Senders may send timed data to receivers by sending data-frame messages (see <a href="#appendix-a">Appendix A: Messages</a>) with the following keys and values.  A data frame message
 contains an arbitrary payload that can be synchronized with and video, such as
 text track data.  A series of data frames that share a data type and timeline
@@ -2828,7 +2872,7 @@ timelines.</p>
      <p>The data.  The format and parameters are inferred from
 the properties of the encoding.</p>
    </dl>
-   <h3 class="heading settled" data-level="8.6" id="streaming-feedback"><span class="secno">8.6. </span><span class="content">Feedback</span><a class="self-link" href="#streaming-feedback"></a></h3>
+   <h3 class="heading settled" data-level="9.6" id="streaming-feedback"><span class="secno">9.6. </span><span class="content">Feedback</span><a class="self-link" href="#streaming-feedback"></a></h3>
    <p>The receiver can send feedback to the sender, such as key frame requests.</p>
    <p>A video key frame is requested by sending a video-request message with
 the following keys and values.</p>
@@ -2849,9 +2893,9 @@ This it to prevent out-of-order requests from generating more key frames than ne
      <p>If set, the sender may generate a video frame dependent on the last decoded
 frame.  If not set, the sender must generate an indepdendent (key) frame.</p>
    </dl>
-   <h3 class="heading settled" data-level="8.7" id="streaming-stats"><span class="secno">8.7. </span><span class="content">Stats</span><a class="self-link" href="#streaming-stats"></a></h3>
+   <h3 class="heading settled" data-level="9.7" id="streaming-stats"><span class="secno">9.7. </span><span class="content">Stats</span><a class="self-link" href="#streaming-stats"></a></h3>
    <p>TODO</p>
-   <h2 class="heading settled" data-level="9" id="security-privacy"><span class="secno">9. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security-privacy"></a></h2>
+   <h2 class="heading settled" data-level="10" id="security-privacy"><span class="secno">10. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security-privacy"></a></h2>
    <p>The Open Screen Protocol allows two networked agents to discover each other
 and exchange user and application data.  As such, its security and privacy
 considerations should be closely examined.  We first evaluate the protocol
@@ -2860,8 +2904,8 @@ Questionnaire</a>.  We then examine whether the security and privacy guidelines
 recommended by the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> and the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> are met.  Finally we discuss recommended
 mitigations that agents can use to meet these security and privacy
 requirements.</p>
-   <h3 class="heading settled" data-level="9.1" id="threat-models"><span class="secno">9.1. </span><span class="content">Threat Models</span><a class="self-link" href="#threat-models"></a></h3>
-   <h4 class="heading settled" data-level="9.1.1" id="passive-network-attackers"><span class="secno">9.1.1. </span><span class="content">Passive Network Attackers</span><a class="self-link" href="#passive-network-attackers"></a></h4>
+   <h3 class="heading settled" data-level="10.1" id="threat-models"><span class="secno">10.1. </span><span class="content">Threat Models</span><a class="self-link" href="#threat-models"></a></h3>
+   <h4 class="heading settled" data-level="10.1.1" id="passive-network-attackers"><span class="secno">10.1.1. </span><span class="content">Passive Network Attackers</span><a class="self-link" href="#passive-network-attackers"></a></h4>
    <p>The Open Screen Protocol should assume that all parties that are connected to
 the same LAN, either through a wired connection or through WiFi, are able to
 observe all data flowing between Open Screen Protocol agents.</p>
@@ -2869,7 +2913,7 @@ observe all data flowing between Open Screen Protocol agents.</p>
 messages, such as mDNS records and the QUIC handshakes.</p>
    <p>These parties may attempt to learn cryptographic parameters by observing data
 flows on the QUIC connection, or by observing cryptographic timing.</p>
-   <h4 class="heading settled" data-level="9.1.2" id="active-network-attackers"><span class="secno">9.1.2. </span><span class="content">Active Network Attackers</span><a class="self-link" href="#active-network-attackers"></a></h4>
+   <h4 class="heading settled" data-level="10.1.2" id="active-network-attackers"><span class="secno">10.1.2. </span><span class="content">Active Network Attackers</span><a class="self-link" href="#active-network-attackers"></a></h4>
    <p>Active attackers, such as compromised routers, will be able to manipulate data
 exchanged between agents.  They can inject traffic into existing QUIC
 connections and attempt to initiate new QUIC connections.  These abilities can
@@ -2889,7 +2933,7 @@ expose local network devices (such as Open Screen Protocol agents) to the
 Internet.  This vector of attack has been used by malicious parties to take
 control of printers and smart TVs by connecting to local network services that
 would normally be inaccessible from the Internet.</p>
-   <h4 class="heading settled" data-level="9.1.3" id="denial-of-service"><span class="secno">9.1.3. </span><span class="content">Denial of Service</span><a class="self-link" href="#denial-of-service"></a></h4>
+   <h4 class="heading settled" data-level="10.1.3" id="denial-of-service"><span class="secno">10.1.3. </span><span class="content">Denial of Service</span><a class="self-link" href="#denial-of-service"></a></h4>
    <p>Parties with connected to the LAN may attempt to deny access to Open Screen
 Protocol agents.  For example, an attacker my attempt to open
 a large number of QUIC connections to an agent in an attempt to block
@@ -2897,7 +2941,7 @@ legitimate connections or exhaust the agent’s system resources.  They may
 also multicast spurious DNS-SD records in an attempt to exhaust the cache
 capacity for mDNS listeners, or to get listeners to open a large number of bogus
 QUIC connections.</p>
-   <h4 class="heading settled" data-level="9.1.4" id="same-origin-policy-violations"><span class="secno">9.1.4. </span><span class="content">Same-Origin Policy Violations</span><a class="self-link" href="#same-origin-policy-violations"></a></h4>
+   <h4 class="heading settled" data-level="10.1.4" id="same-origin-policy-violations"><span class="secno">10.1.4. </span><span class="content">Same-Origin Policy Violations</span><a class="self-link" href="#same-origin-policy-violations"></a></h4>
    <p>The Presentation API allows cross-origin communication between controlling pages
 and presentations with the consent of each origin (through their use of the
 API).  This is similar to cross-origin communication via <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage" id="ref-for-dom-window-postmessage">postMessage()</a></code> with a <code>targetOrigin</code> of <code>*</code>.  However, the Presentation API does not convey source
@@ -2905,8 +2949,8 @@ origin information with each message.  Therefore, the Open Screen Protocol does
 not convey origin information between its agents.</p>
    <p>The <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-id" id="ref-for-dfn-presentation-id③">presentation ID</a> carries some protection against unrestricted
 cross-origin access; but, rigorous authentication of the parties connected by a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection②">PresentationConnection</a></code> must be done at the application level.</p>
-   <h3 class="heading settled" data-level="9.2" id="security-privacy-questions"><span class="secno">9.2. </span><span class="content">Open Screen Protocol Security and Privacy Considerations</span><a class="self-link" href="#security-privacy-questions"></a></h3>
-   <h4 class="heading settled" data-level="9.2.1" id="personally-identifiable-information"><span class="secno">9.2.1. </span><span class="content">Personally Identifiable Information &amp; High-Value Data</span><a class="self-link" href="#personally-identifiable-information"></a></h4>
+   <h3 class="heading settled" data-level="10.2" id="security-privacy-questions"><span class="secno">10.2. </span><span class="content">Open Screen Protocol Security and Privacy Considerations</span><a class="self-link" href="#security-privacy-questions"></a></h3>
+   <h4 class="heading settled" data-level="10.2.1" id="personally-identifiable-information"><span class="secno">10.2.1. </span><span class="content">Personally Identifiable Information &amp; High-Value Data</span><a class="self-link" href="#personally-identifiable-information"></a></h4>
    <p>The following data exchanged by the protocol can be personally identifiable
 and/or high value data:</p>
    <ol>
@@ -2938,20 +2982,20 @@ considered public and untrusted data:</p>
      <p>Data advertised through mDNS, including the display name prefix, the
 certificate fingerprint, and the metadata version.</p>
    </ol>
-   <h4 class="heading settled" data-level="9.2.2" id="cross-origin-state"><span class="secno">9.2.2. </span><span class="content">Cross Origin State Considerations</span><a class="self-link" href="#cross-origin-state"></a></h4>
+   <h4 class="heading settled" data-level="10.2.2" id="cross-origin-state"><span class="secno">10.2.2. </span><span class="content">Cross Origin State Considerations</span><a class="self-link" href="#cross-origin-state"></a></h4>
    <p>Access to origin state across browsing sessions is possible through the
 Presentation API by reconnecting to a presentation that was started by a
 previous session. This scenario is addressed in <a href="https://www.w3.org/TR/presentation-api/#cross-origin-access">Presentation API §cross-origin-access</a>.</p>
    <p>Presentation display availability and remote playback device availability are
 states that are available cross-origin depending on the user’s network
 context.  Exposure of this data to the Web is also discussed in <a href="https://www.w3.org/TR/presentation-api/#personally-identifiable-information">Presentation API §personally-identifiable-information</a> and <a href="https://www.w3.org/TR/remote-playback/#personally-identifiable-information">Remote Playback API §personally-identifiable-information</a>.</p>
-   <h4 class="heading settled" data-level="9.2.3" id="origin-access-devices"><span class="secno">9.2.3. </span><span class="content">Origin Access to Other Devices</span><a class="self-link" href="#origin-access-devices"></a></h4>
+   <h4 class="heading settled" data-level="10.2.3" id="origin-access-devices"><span class="secno">10.2.3. </span><span class="content">Origin Access to Other Devices</span><a class="self-link" href="#origin-access-devices"></a></h4>
    <p>By design, the Open Screen Protocol allows access to presentation displays and
 remote playback devices from the Web.  By implementing the protocol, these
 devices are knowingly making themselves available to the Web and should be
 designed accordingly.</p>
    <p>Below, we discuss mitigation steps to prevent malicious use of these devices.</p>
-   <h4 class="heading settled" data-level="9.2.4" id="incognito-mode"><span class="secno">9.2.4. </span><span class="content">Incognito Mode</span><a class="self-link" href="#incognito-mode"></a></h4>
+   <h4 class="heading settled" data-level="10.2.4" id="incognito-mode"><span class="secno">10.2.4. </span><span class="content">Incognito Mode</span><a class="self-link" href="#incognito-mode"></a></h4>
    <p>The Open Screen Protocol does not distinguish between the user agent’s normal
 browsing and incognito modes, and agents that follow the specification
 behave identically regardless of which mode is in use.</p>
@@ -2959,7 +3003,7 @@ behave identically regardless of which mode is in use.</p>
 connections for normal and incognito profiles from the same user agent instance.
 This prevents Open Screen agents from correlating activity among profiles
 belonging to the same user (both normal and incognito).</p>
-   <h4 class="heading settled" data-level="9.2.5" id="persistent-state"><span class="secno">9.2.5. </span><span class="content">Persistent State</span><a class="self-link" href="#persistent-state"></a></h4>
+   <h4 class="heading settled" data-level="10.2.5" id="persistent-state"><span class="secno">10.2.5. </span><span class="content">Persistent State</span><a class="self-link" href="#persistent-state"></a></h4>
    <p>An agent is likely to persist the identity of agents that have successfully
 completed <a href="#authentication">§6 Authentication</a>.  This may include the public key fingerprints,
 metadata versions, and metadata for those parties.</p>
@@ -2968,7 +3012,7 @@ UI of the user agent during the display selection or display authentication
 process.  It can be an implementation choice whether the user agent clears or
 retains this data when the user clears browsing data.</p>
    <p class="issue" id="issue-8bf4aa9f"><a class="self-link" href="#issue-8bf4aa9f"></a> Fate of metadata / authentication history when clearing browsing data. <a href="https://github.com/webscreens/openscreenprotocol/issues/132">&lt;https://github.com/webscreens/openscreenprotocol/issues/132></a></p>
-   <h4 class="heading settled" data-level="9.2.6" id="other-considerations"><span class="secno">9.2.6. </span><span class="content">Other Considerations</span><a class="self-link" href="#other-considerations"></a></h4>
+   <h4 class="heading settled" data-level="10.2.6" id="other-considerations"><span class="secno">10.2.6. </span><span class="content">Other Considerations</span><a class="self-link" href="#other-considerations"></a></h4>
    <p>The Open Screen Protocol does not grant to the Web additional access to the
 following:</p>
    <ul>
@@ -2985,7 +3029,7 @@ following:</p>
     <li data-md>
      <p>Security characteristics of the user agent</p>
    </ul>
-   <h3 class="heading settled" data-level="9.3" id="presentation-api-considerations"><span class="secno">9.3. </span><span class="content">Presentation API Considerations</span><a class="self-link" href="#presentation-api-considerations"></a></h3>
+   <h3 class="heading settled" data-level="10.3" id="presentation-api-considerations"><span class="secno">10.3. </span><span class="content">Presentation API Considerations</span><a class="self-link" href="#presentation-api-considerations"></a></h3>
    <p><a href="https://www.w3.org/TR/presentation-api/#security-and-privacy-considerations">Presentation API §security-and-privacy-considerations</a> place these
 requirements on the Open Screen Protocol:</p>
    <ol>
@@ -3012,15 +3056,15 @@ connections.</p>
  the number of active connections.</p>
    </ol>
    <p class="issue" id="issue-edc1d8c1"><a class="self-link" href="#issue-edc1d8c1"></a> Notify endpoints when new connection is created. <a href="https://github.com/webscreens/openscreenprotocol/issues/143">&lt;https://github.com/webscreens/openscreenprotocol/issues/143></a></p>
-   <h3 class="heading settled" data-level="9.4" id="remote-playback-considerations"><span class="secno">9.4. </span><span class="content">Remote Playback API Considerations</span><a class="self-link" href="#remote-playback-considerations"></a></h3>
+   <h3 class="heading settled" data-level="10.4" id="remote-playback-considerations"><span class="secno">10.4. </span><span class="content">Remote Playback API Considerations</span><a class="self-link" href="#remote-playback-considerations"></a></h3>
    <p>The <a href="https://www.w3.org/TR/remote-playback/#security-and-privacy-considerations">Remote Playback API §security-and-privacy-considerations</a> also state that
 messaging between local and remote playback devices should also be authenticated
 and confidential.</p>
    <p>This consideration is handled by requiring mutual authentication and a
 TLS-secured QUIC connection before any remote playback related messages are
 exchanged.</p>
-   <h3 class="heading settled" data-level="9.5" id="security-mitigations"><span class="secno">9.5. </span><span class="content">Mitigation Strategies</span><a class="self-link" href="#security-mitigations"></a></h3>
-   <h4 class="heading settled" data-level="9.5.1" id="local-passive-mitigations"><span class="secno">9.5.1. </span><span class="content">Local passive network attackers</span><a class="self-link" href="#local-passive-mitigations"></a></h4>
+   <h3 class="heading settled" data-level="10.5" id="security-mitigations"><span class="secno">10.5. </span><span class="content">Mitigation Strategies</span><a class="self-link" href="#security-mitigations"></a></h3>
+   <h4 class="heading settled" data-level="10.5.1" id="local-passive-mitigations"><span class="secno">10.5.1. </span><span class="content">Local passive network attackers</span><a class="self-link" href="#local-passive-mitigations"></a></h4>
    <p>Local passive attackers may attempt to harvest data about user activities and
 device capabilities using the Open Screen Protocol.  The main strategy to address
 this is data minimization, by only exposing opaque public key fingerprints
@@ -3028,7 +3072,7 @@ before user-mediated authentication takes place.</p>
    <p>Passive attackers may also attempt timing attacks to learn the
 cryptographic parameters of the TLS 1.3 QUIC connection.</p>
    <p class="issue" id="issue-84520e29"><a class="self-link" href="#issue-84520e29"></a> Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a></p>
-   <h4 class="heading settled" data-level="9.5.2" id="local-active-mitigations"><span class="secno">9.5.2. </span><span class="content">Local active network attackers</span><a class="self-link" href="#local-active-mitigations"></a></h4>
+   <h4 class="heading settled" data-level="10.5.2" id="local-active-mitigations"><span class="secno">10.5.2. </span><span class="content">Local active network attackers</span><a class="self-link" href="#local-active-mitigations"></a></h4>
    <p>Local active attackers may attempt to impersonate a presentation display the
 user would normally trust.  The <a href="#authentication">§6 Authentication</a> step of the Open Screen
 Protocol prevents a man-in-the-middle from impersonating an agent, without
@@ -3075,19 +3119,19 @@ display - to prevent the user from blindly clicking through this step.</p>
 connection by injecting or modifying traffic.  These attacks should be mitigated
 by a correct implementation of TLS 1.3.</p>
    <p class="issue" id="issue-84520e29①"><a class="self-link" href="#issue-84520e29①"></a> Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a></p>
-   <h4 class="heading settled" data-level="9.5.3" id="remote-active-mitigations"><span class="secno">9.5.3. </span><span class="content">Remote active network attackers</span><a class="self-link" href="#remote-active-mitigations"></a></h4>
+   <h4 class="heading settled" data-level="10.5.3" id="remote-active-mitigations"><span class="secno">10.5.3. </span><span class="content">Remote active network attackers</span><a class="self-link" href="#remote-active-mitigations"></a></h4>
    <p>Unfortunately, we cannot rely on network devices to fully protect Open Screen
 Protocol agents, because a misconfigured firewall or NAT could expose a
 LAN-connected agent to the broader Internet.  Open Screen Protocol agents
 should be secure against attack from any Internet host.</p>
    <p class="issue" id="issue-7e863472"><a class="self-link" href="#issue-7e863472"></a> Mitigations for remote network attackers. <a href="https://github.com/webscreens/openscreenprotocol/issues/131">&lt;https://github.com/webscreens/openscreenprotocol/issues/131></a></p>
-   <h4 class="heading settled" data-level="9.5.4" id="denial-of-service-mitigations"><span class="secno">9.5.4. </span><span class="content">Denial of service</span><a class="self-link" href="#denial-of-service-mitigations"></a></h4>
+   <h4 class="heading settled" data-level="10.5.4" id="denial-of-service-mitigations"><span class="secno">10.5.4. </span><span class="content">Denial of service</span><a class="self-link" href="#denial-of-service-mitigations"></a></h4>
    <p>It will be difficult to completely prevent denial service of attacks that
 originate on the user’s local area network.  Open Screen Protocol agents can
 refuse new connections, close connections that receive too many messages, or
 limit the number of mDNS records cached from a specific responder in an attempt
 to allow existing activities to continue in spite of such an attack.</p>
-   <h4 class="heading settled" data-level="9.5.5" id="malicious-input-mitigations"><span class="secno">9.5.5. </span><span class="content">Malicious input</span><a class="self-link" href="#malicious-input-mitigations"></a></h4>
+   <h4 class="heading settled" data-level="10.5.5" id="malicious-input-mitigations"><span class="secno">10.5.5. </span><span class="content">Malicious input</span><a class="self-link" href="#malicious-input-mitigations"></a></h4>
    <p>Open Screen Protocol agents should be robust against malicious input that
 attempts to compromise the target device by exploiting parsing vulnerabilities.</p>
    <p>CBOR is intended to be less vulnerable to such attacks relative to alternatives
@@ -3835,21 +3879,21 @@ because smaller type keys encode on the wire smaller.</p>
   <aside class="dfn-panel" data-for="term-for-dom-window-postmessage">
    <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-window-postmessage">9.1.4. Same-Origin Policy Violations</a>
+    <li><a href="#ref-for-dom-window-postmessage">10.1.4. Same-Origin Policy Violations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-presentationconnection">
    <a href="https://w3c.github.io/presentation-api/#presentationconnection">https://w3c.github.io/presentation-api/#presentationconnection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-presentationconnection">2.1. Presentation API Requirements</a> <a href="#ref-for-presentationconnection①">(2)</a>
-    <li><a href="#ref-for-presentationconnection②">9.1.4. Same-Origin Policy Violations</a>
-    <li><a href="#ref-for-presentationconnection③">9.3. Presentation API Considerations</a>
+    <li><a href="#ref-for-presentationconnection②">10.1.4. Same-Origin Policy Violations</a>
+    <li><a href="#ref-for-presentationconnection③">10.3. Presentation API Considerations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-available-presentation-display">
    <a href="https://w3c.github.io/presentation-api/#dfn-available-presentation-display">https://w3c.github.io/presentation-api/#dfn-available-presentation-display</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-available-presentation-display">7.1. Presentation Protocol</a>
+    <li><a href="#ref-for-dfn-available-presentation-display">8.1. Presentation Protocol</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-controller">
@@ -3863,7 +3907,7 @@ because smaller type keys encode on the wire smaller.</p>
    <ul>
     <li><a href="#ref-for-dfn-controlling-user-agent">1.1. Terminology</a>
     <li><a href="#ref-for-dfn-controlling-user-agent①">2.1. Presentation API Requirements</a>
-    <li><a href="#ref-for-dfn-controlling-user-agent②">7.2. Presentation API</a> <a href="#ref-for-dfn-controlling-user-agent③">(2)</a> <a href="#ref-for-dfn-controlling-user-agent④">(3)</a> <a href="#ref-for-dfn-controlling-user-agent⑤">(4)</a> <a href="#ref-for-dfn-controlling-user-agent⑥">(5)</a>
+    <li><a href="#ref-for-dfn-controlling-user-agent②">8.2. Presentation API</a> <a href="#ref-for-dfn-controlling-user-agent③">(2)</a> <a href="#ref-for-dfn-controlling-user-agent④">(3)</a> <a href="#ref-for-dfn-controlling-user-agent⑤">(4)</a> <a href="#ref-for-dfn-controlling-user-agent⑥">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-presentation-display">
@@ -3882,7 +3926,7 @@ because smaller type keys encode on the wire smaller.</p>
    <a href="https://w3c.github.io/presentation-api/#dfn-presentation-id">https://w3c.github.io/presentation-api/#dfn-presentation-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-presentation-id">2.1. Presentation API Requirements</a> <a href="#ref-for-dfn-presentation-id①">(2)</a> <a href="#ref-for-dfn-presentation-id②">(3)</a>
-    <li><a href="#ref-for-dfn-presentation-id③">9.1.4. Same-Origin Policy Violations</a>
+    <li><a href="#ref-for-dfn-presentation-id③">10.1.4. Same-Origin Policy Violations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-presentation-request-url">
@@ -3896,47 +3940,47 @@ because smaller type keys encode on the wire smaller.</p>
    <a href="https://w3c.github.io/presentation-api/#dfn-receiver">https://w3c.github.io/presentation-api/#dfn-receiver</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-receiver">1.1. Terminology</a> <a href="#ref-for-dfn-receiver①">(2)</a>
-    <li><a href="#ref-for-dfn-receiver②">7.1. Presentation Protocol</a>
+    <li><a href="#ref-for-dfn-receiver②">8.1. Presentation Protocol</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-receiving-user-agent">
    <a href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent">https://w3c.github.io/presentation-api/#dfn-receiving-user-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-receiving-user-agent">1.1. Terminology</a>
-    <li><a href="#ref-for-dfn-receiving-user-agent①">7.2. Presentation API</a> <a href="#ref-for-dfn-receiving-user-agent②">(2)</a>
+    <li><a href="#ref-for-dfn-receiving-user-agent①">8.2. Presentation API</a> <a href="#ref-for-dfn-receiving-user-agent②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-availability-sources-set">
    <a href="https://w3c.github.io/remote-playback/#dfn-availability-sources-set">https://w3c.github.io/remote-playback/#dfn-availability-sources-set</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-availability-sources-set">7.5. Remote Playback API</a>
+    <li><a href="#ref-for-dfn-availability-sources-set">8.5. Remote Playback API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-compatible-remote-playback-device">
    <a href="https://w3c.github.io/remote-playback/#dfn-compatible-remote-playback-device">https://w3c.github.io/remote-playback/#dfn-compatible-remote-playback-device</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-compatible-remote-playback-device">7.3. Remote Playback Protocol</a>
+    <li><a href="#ref-for-dfn-compatible-remote-playback-device">8.3. Remote Playback Protocol</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-media-resources">
    <a href="https://w3c.github.io/remote-playback/#dfn-media-resources">https://w3c.github.io/remote-playback/#dfn-media-resources</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-media-resources">7.3. Remote Playback Protocol</a> <a href="#ref-for-dfn-media-resources①">(2)</a> <a href="#ref-for-dfn-media-resources②">(3)</a> <a href="#ref-for-dfn-media-resources③">(4)</a>
-    <li><a href="#ref-for-dfn-media-resources④">7.4. Remote Playback State and Controls</a> <a href="#ref-for-dfn-media-resources⑤">(2)</a> <a href="#ref-for-dfn-media-resources⑥">(3)</a> <a href="#ref-for-dfn-media-resources⑦">(4)</a> <a href="#ref-for-dfn-media-resources⑧">(5)</a>
+    <li><a href="#ref-for-dfn-media-resources">8.3. Remote Playback Protocol</a> <a href="#ref-for-dfn-media-resources①">(2)</a> <a href="#ref-for-dfn-media-resources②">(3)</a> <a href="#ref-for-dfn-media-resources③">(4)</a>
+    <li><a href="#ref-for-dfn-media-resources④">8.4. Remote Playback State and Controls</a> <a href="#ref-for-dfn-media-resources⑤">(2)</a> <a href="#ref-for-dfn-media-resources⑥">(3)</a> <a href="#ref-for-dfn-media-resources⑦">(4)</a> <a href="#ref-for-dfn-media-resources⑧">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-remote-playback-devices">
    <a href="https://w3c.github.io/remote-playback/#dfn-remote-playback-devices">https://w3c.github.io/remote-playback/#dfn-remote-playback-devices</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-remote-playback-devices">1.1. Terminology</a>
-    <li><a href="#ref-for-dfn-remote-playback-devices①">7.3. Remote Playback Protocol</a>
-    <li><a href="#ref-for-dfn-remote-playback-devices②">7.5. Remote Playback API</a>
+    <li><a href="#ref-for-dfn-remote-playback-devices①">8.3. Remote Playback Protocol</a>
+    <li><a href="#ref-for-dfn-remote-playback-devices②">8.5. Remote Playback API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-remote-playback-source">
    <a href="https://w3c.github.io/remote-playback/#dfn-remote-playback-source">https://w3c.github.io/remote-playback/#dfn-remote-playback-source</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-remote-playback-source">7.5. Remote Playback API</a>
+    <li><a href="#ref-for-dfn-remote-playback-source">8.5. Remote Playback API</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version ee4d7efc3ed6155392d49e10a542e2351fd5792d" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="d9b360ffa3c2624da5de3a7e2f216a85846535fa" name="document-revision">
+  <meta content="0580952ce4d0b4aeeb7282a8673e76d267c314e9" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -3197,6 +3197,30 @@ because smaller type keys encode on the wire smaller.</p>
 <span class="nx">auth-capabilities </span><span class="p">=</span> <span class="p">{</span>
   <span class="mi">0</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; psk-ease-of-input</span>
   <span class="mi">1</span><span class="p">:</span> <span class="p">[</span><span class="o">*</span> <span class="nx">psk-input-method</span><span class="p">]</span> <span class="c1">; psk-input-methods</span>
+<span class="p">}</span></p>
+
+<p><span class="c1">; type key 1005</span>
+<span class="nx">auth-jpake-round1 </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="nx">bytes </span><span class="c1">; g1</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="nx">zero-knowledge-proof </span><span class="c1">; x1-zkp</span>
+  <span class="mi">2</span><span class="p">:</span> <span class="nx">bytes </span><span class="c1">; g2</span>
+  <span class="mi">3</span><span class="p">:</span> <span class="nx">zero-knowledge-proof </span><span class="c1">; x2-zkp</span>
+<span class="p">}</span></p>
+
+<p><span class="nx">zero-knowledge-proof </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="nx">bytes </span><span class="c1">; gv</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="nx">bytes </span><span class="c1">; r</span>
+<span class="p">}</span></p>
+
+<p><span class="c1">; type key 1006</span>
+<span class="nx">auth-jpake-round2 </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="nx">bytes </span><span class="c1">; a</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="nx">zero-knowledge-proof</span><span class="c1">; x2s-zkp</span>
+<span class="p">}</span></p>
+
+<p><span class="c1">; type key 1007</span>
+<span class="nx">auth-jpake-confirmation </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="nx">bytes </span><span class="c1">; hashed-key</span>
 <span class="p">}</span></p>
 
 <p><span class="nx">psk-input-method </span><span class="p">=</span> <span class="o">&amp;</span><span class="p">(</span>

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -86,6 +86,30 @@ auth-capabilities = {
   1: [* psk-input-method] ; psk-input-methods
 }
 
+; type key 1005
+auth-jpake-round1 = {
+  0: bytes ; g1
+  1: zero-knowledge-proof ; x1-zkp
+  2: bytes ; g2
+  3: zero-knowledge-proof ; x2-zkp
+}
+
+zero-knowledge-proof = {
+  0: bytes ; gv
+  1: bytes ; r
+}
+
+; type key 1006
+auth-jpake-round2 = {
+  0: bytes ; a
+  1: zero-knowledge-proof; x2s-zkp
+}
+
+; type key 1007
+auth-jpake-confirmation = {
+  0: bytes ; hashed-key
+}
+
 psk-input-method = &(
   numeric: 0
   alphanumeric: 1

--- a/messages_appendix.html
+++ b/messages_appendix.html
@@ -86,6 +86,30 @@
   <span class="mi">1</span><span class="p">:</span> <span class="p">[</span><span class="o">*</span> <span class="nx">psk-input-method</span><span class="p">]</span> <span class="c1">; psk-input-methods</span>
 <span class="p">}</span>
 
+<span class="c1">; type key 1005</span>
+<span class="nx">auth-jpake-round1 </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="nx">bytes </span><span class="c1">; g1</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="nx">zero-knowledge-proof </span><span class="c1">; x1-zkp</span>
+  <span class="mi">2</span><span class="p">:</span> <span class="nx">bytes </span><span class="c1">; g2</span>
+  <span class="mi">3</span><span class="p">:</span> <span class="nx">zero-knowledge-proof </span><span class="c1">; x2-zkp</span>
+<span class="p">}</span>
+
+<span class="nx">zero-knowledge-proof </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="nx">bytes </span><span class="c1">; gv</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="nx">bytes </span><span class="c1">; r</span>
+<span class="p">}</span>
+
+<span class="c1">; type key 1006</span>
+<span class="nx">auth-jpake-round2 </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="nx">bytes </span><span class="c1">; a</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="nx">zero-knowledge-proof</span><span class="c1">; x2s-zkp</span>
+<span class="p">}</span>
+
+<span class="c1">; type key 1007</span>
+<span class="nx">auth-jpake-confirmation </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">0</span><span class="p">:</span> <span class="nx">bytes </span><span class="c1">; hashed-key</span>
+<span class="p">}</span>
+
 <span class="nx">psk-input-method </span><span class="p">=</span> <span class="o">&amp;</span><span class="p">(</span>
   <span class="nx">numeric</span><span class="p">:</span> <span class="mi">0</span>
   <span class="nx">alphanumeric</span><span class="p">:</span> <span class="mi">1</span>


### PR DESCRIPTION
CDDL message definitions for J-PAKE authentication protocol. The protocol is completely symmetric, both sides can use the same message format. Fields are named from the message sender perspective.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/maxyakimakha/openscreenprotocol/pull/164.html" title="Last updated on May 20, 2019, 6:27 PM UTC (5fddd56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/164/0580952...maxyakimakha:5fddd56.html" title="Last updated on May 20, 2019, 6:27 PM UTC (5fddd56)">Diff</a>