### PR TITLE
Additional changes related to PR #179 (agent display name).

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -150,7 +150,7 @@ Presentation API Requirements {#requirements-presentation-api}
     by IP multicast.
 
 2.  A controlling user agent must be able to obtain the IPv4 or IPv6 address of
-    the display, a friendly name for the display, and an IP port number for
+    the display, a display name for the display, and an IP port number for
     establishing a network transport to the display.
 
 3.  A controlling user agent must be able to determine if the receiver is
@@ -280,25 +280,29 @@ Non-Functional Requirements {#requirements-non-functional}
 Discovery with mDNS {#discovery}
 ===============================
 
-Agents may discover one another using [[RFC6763|DNS-SD]] over [[RFC6762|mDNS]].
-To do so, agents must use the service name "_openscreen._udp.local".
+Agents must discover one another using [[RFC6763|DNS-SD]] over [[RFC6762|mDNS]].
+To do so, agents must use the service name `_openscreen._udp.local`.
 
 Issue(107): Define suspend and resume behavior for discovery protocol.
 
-Advertising Agents must use an instance name that is a prefix of the agent's
-display name. If the instance name is not the complete display name (if it has
-been truncated), it must be terminated by a null character.  It is prefix so
-that the name displayed to the user pre-verification can be verified later.  It
-is terminated by a null character in the case of truncation so that the
-listening agent knows it has been truncated.  This complexity is necessary to
-all for display names that exceed the size allowed in an instance name and for
-such (possibly  truncated) display names to be visible to the user sooner
-(before a QUIC connection is made).  Listening agents must treat instance names
-as unverified and must verify that the instance name is a prefix of the verified
-display name before showing the user a verified display name.
+An <dfn noexport>advertising agent</dfn> is one that responds to mDNS queries
+for `_openscreen._udp.local`.  Such an agent should have a <dfn noexport>display
+name</dfn> (a non-empty string) that is a human readable description of the
+presentation display, e.g. "Living Room TV."
 
-Agents should use the complete display name to the user rather than a
-truncated display name.
+A <dfn noexport>listening agent</dfn> is one that sends mDNS queries for
+`_openscreen._udp.local`.  Listening agents may have a display name.
+
+Advertising agents must use an DNS-SD instance name that is a prefix of the
+agent's display name.  If the instance name is not the complete display name, it
+must be terminated by a null (`\000`) character, so that a listening agent knows
+it has been truncated.  Agents must show only complete display names to the
+user, and never truncated display names.
+
+Agents must treat instance names as unverified information, and should check that
+the instance name is a prefix of the display name received through the
+`agent-info` message after a successful QUIC connection.  Once an agent has done
+this check, it can show the name as a <dfn noexport>verified display name</dfn>.
 
 Advertising agents must include DNS TXT records with the following
 keys and values:
@@ -1652,7 +1656,7 @@ and/or high value data:
 Presentation IDs are considered high value data because they can be used in
 conjunction with a Presentation URL to connect to a running presentation.
 
-Presentation display friendly names, model names, and capabilities, while not
+Presentation display names, model names, and capabilities, while not
 considered personally identifiable, are important to protect to prevent an
 attacker from changing them or substituting other values during the discovery
 and authentication process.
@@ -1789,10 +1793,10 @@ should be flagged include:
 
 * Untrusted agents whose public key fingerprint collides with that from an
     already-trusted agent that is concurrently being advertised.
-* Untrusted agents whose friendly name differs from the one previously
+* Untrusted agents whose display name differs from the one previously
     advertised under a given public key fingerprint.
 * Untrusted agents that fail the authentication challenge a certain number of times.
-* Untrusted agents that advertise a friendly name that is similar to that from an
+* Untrusted agents that advertise a display name that is similar to that from an
     already-trusted agent.
 * Already-trusted agents whose metadata provided through the `agent-info`
     message has changed.

--- a/index.bs
+++ b/index.bs
@@ -61,6 +61,8 @@ urlPrefix: https://w3c.github.io/remote-playback/#dfn-; type: dfn; spec: REMOTE-
     text: remote playback source
 urlPrefix: https://www.w3.org/TR/html51/single-page.html; type: dfn; spec: HTML51
     text: media element
+url: https://tools.ietf.org/html/rfc6763#section-7; type: dfn; spec: RFC6763; text: service name
+url: https://tools.ietf.org/html/rfc6763#section-4.1.1; type: dfn; spec: RFC6763; text: instance name
 </pre>
 
 <h2 class='no-num no-toc no-ref' id='status'>Status of this document</h2>
@@ -281,7 +283,7 @@ Discovery with mDNS {#discovery}
 ===============================
 
 Agents must discover one another using [[RFC6763|DNS-SD]] over [[RFC6762|mDNS]].
-To do so, agents must use the service name `_openscreen._udp.local`.
+To do so, agents must use the [=Service Name=] `_openscreen._udp.local`.
 
 Issue(107): Define suspend and resume behavior for discovery protocol.
 
@@ -293,13 +295,13 @@ presentation display, e.g. "Living Room TV."
 A <dfn noexport>listening agent</dfn> is one that sends mDNS queries for
 `_openscreen._udp.local`.  Listening agents may have a display name.
 
-Advertising agents must use an DNS-SD instance name that is a prefix of the
-agent's display name.  If the instance name is not the complete display name, it
+Advertising agents must use a DNS-SD [=Instance Name=] that is a prefix of the
+agent's display name.  If the Instance Name is not the complete display name, it
 must be terminated by a null (`\000`) character, so that a listening agent knows
 it has been truncated.
 
-Agents must treat instance names as unverified information, and should check
-that the instance name is a prefix of the display name received through the
+Agents must treat Instance Names as unverified information, and should check
+that the Instance Name is a prefix of the display name received through the
 `agent-info` message after a successful QUIC connection.  Once an agent has done
 this check, it can show the name as a <dfn noexport>verified display name</dfn>.
 
@@ -311,8 +313,8 @@ before being shown in full as a [=verified display name=].
 This means there are three categories of display names that agents should be
 capable of handling:
 <ol>
-  <li>Truncated and unverified DNS-SD instance names, which should not be shown to the user.</li>
-  <li>Complete but unverified DNS-SD instance names, which can be shown as
+  <li>Truncated and unverified DNS-SD Instance Names, which should not be shown to the user.</li>
+  <li>Complete but unverified DNS-SD Instance Names, which can be shown as
      unverified prior to [[#authentication]].</li>
   <li>Verified display names.</li>
 </ol>

--- a/index.bs
+++ b/index.bs
@@ -296,13 +296,27 @@ A <dfn noexport>listening agent</dfn> is one that sends mDNS queries for
 Advertising agents must use an DNS-SD instance name that is a prefix of the
 agent's display name.  If the instance name is not the complete display name, it
 must be terminated by a null (`\000`) character, so that a listening agent knows
-it has been truncated.  Agents must show only complete display names to the
-user, and never truncated display names.
+it has been truncated.
 
-Agents must treat instance names as unverified information, and should check that
-the instance name is a prefix of the display name received through the
+Agents must treat instance names as unverified information, and should check
+that the instance name is a prefix of the display name received through the
 `agent-info` message after a successful QUIC connection.  Once an agent has done
 this check, it can show the name as a <dfn noexport>verified display name</dfn>.
+
+Agents should show only complete display names to the user, instead of truncated
+display names from DNS-SD.  A truncated display name should be verified as above
+before being shown in full as a [=verified display name=].
+
+<div class="note">
+This means there are three categories of display names that agents should be
+capable of handling:
+<ol>
+  <li>Truncated and unverified DNS-SD instance names, which should not be shown to the user.</li>
+  <li>Complete but unverified DNS-SD instance names, which can be shown as
+     unverified prior to [[#authentication]].</li>
+  <li>Verified display names.</li>
+</ol>
+</div>
 
 Advertising agents must include DNS TXT records with the following
 keys and values:

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="5a073d21fafe614cb4571349eeadf19bc25fd5dd" name="document-revision">
+  <meta content="a35d714e86749a345a6d09c473eedf0bc7dafb12" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-06">6 August 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-07">7 August 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1765,19 +1765,19 @@ APIs.</p>
    </ol>
    <h2 class="heading settled" data-level="3" id="discovery"><span class="secno">3. </span><span class="content">Discovery with mDNS</span><a class="self-link" href="#discovery"></a></h2>
    <p>Agents must discover one another using <a data-link-type="biblio" href="#biblio-rfc6763">DNS-SD</a> over <a data-link-type="biblio" href="#biblio-rfc6762">mDNS</a>.
-To do so, agents must use the service name <code>_openscreen._udp.local</code>.</p>
+To do so, agents must use the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6763#section-7" id="ref-for-section-7">Service Name</a> <code>_openscreen._udp.local</code>.</p>
    <p class="issue" id="issue-56c2cd35"><a class="self-link" href="#issue-56c2cd35"></a> Define suspend and resume behavior for discovery protocol. <a href="https://github.com/webscreens/openscreenprotocol/issues/107">&lt;https://github.com/webscreens/openscreenprotocol/issues/107></a></p>
    <p>An <dfn data-dfn-type="dfn" data-noexport id="advertising-agent">advertising agent<a class="self-link" href="#advertising-agent"></a></dfn> is one that responds to mDNS queries
 for <code>_openscreen._udp.local</code>.  Such an agent should have a <dfn data-dfn-type="dfn" data-lt="display name" data-noexport id="display-name">display
 name<a class="self-link" href="#display-name"></a></dfn> (a non-empty string) that is a human readable description of the
 presentation display, e.g. "Living Room TV."</p>
    <p>A <dfn data-dfn-type="dfn" data-noexport id="listening-agent">listening agent<a class="self-link" href="#listening-agent"></a></dfn> is one that sends mDNS queries for <code>_openscreen._udp.local</code>.  Listening agents may have a display name.</p>
-   <p>Advertising agents must use an DNS-SD instance name that is a prefix of the
-agent’s display name.  If the instance name is not the complete display name, it
+   <p>Advertising agents must use a DNS-SD <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6763#section-4.1.1" id="ref-for-section-4.1.1">Instance Name</a> that is a prefix of the
+agent’s display name.  If the Instance Name is not the complete display name, it
 must be terminated by a null (<code>\000</code>) character, so that a listening agent knows
 it has been truncated.</p>
-   <p>Agents must treat instance names as unverified information, and should check
-that the instance name is a prefix of the display name received through the <code>agent-info</code> message after a successful QUIC connection.  Once an agent has done
+   <p>Agents must treat Instance Names as unverified information, and should check
+that the Instance Name is a prefix of the display name received through the <code>agent-info</code> message after a successful QUIC connection.  Once an agent has done
 this check, it can show the name as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="verified-display-name">verified display name</dfn>.</p>
    <p>Agents should show only complete display names to the user, instead of truncated
 display names from DNS-SD.  A truncated display name should be verified as above
@@ -1786,8 +1786,8 @@ before being shown in full as a <a data-link-type="dfn" href="#verified-display-
      This means there are three categories of display names that agents should be
 capable of handling: 
     <ol>
-     <li>Truncated and unverified DNS-SD instance names, which should not be shown to the user.
-     <li>Complete but unverified DNS-SD instance names, which can be shown as
+     <li>Truncated and unverified DNS-SD Instance Names, which should not be shown to the user.
+     <li>Complete but unverified DNS-SD Instance Names, which can be shown as
      unverified prior to <a href="#authentication">§ 6 Authentication</a>.
      <li>Verified display names.
     </ol>
@@ -3149,11 +3149,24 @@ because smaller type keys encode on the wire smaller.</p>
 <span class="nx">  1</span><span class="p">:</span> <span class="nx">agent-info </span><span class="c1">; agent-info</span>
 <span class="p">}</span></p>
 
+<p><span class="nx">agent-capability </span><span class="p">=</span> <span class="o">&amp;</span><span class="p">(</span>
+  <span class="nx">receive-audio</span><span class="p">:</span> <span class="mi">1</span>
+  <span class="nx">receive-video</span><span class="p">:</span> <span class="mi">2</span></p>
+
+<p><span class="nx">receive-presentation</span><span class="p">:</span> <span class="mi">2</span>
+  <span class="nx">control-presentation</span><span class="p">:</span> <span class="mi">3</span></p>
+
+<p><span class="nx">receive-remote-playback</span><span class="p">:</span> <span class="mi">4</span>
+  <span class="nx">control-remote-playback</span><span class="p">:</span> <span class="mi">5</span></p>
+
+<p><span class="nx">receive-streaming</span><span class="p">:</span> <span class="mi">6</span>
+  <span class="nx">send-streaming</span><span class="p">:</span> <span class="mi">7</span>
+<span class="p">)</span></p>
+
 <p><span class="nx">agent-info </span><span class="p">=</span> <span class="p">{</span>
   <span class="mi">0</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; display-name</span>
   <span class="mi">1</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; model-name</span>
-  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; receives-audio</span>
-  <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; receives-video</span>
+  <span class="mi">2</span><span class="p">:</span> <span class="p">[</span><span class="o">*</span> <span class="nx">agent-capabilitiy</span><span class="p">]</span> <span class="c1">; capabilities</span>
 <span class="p">}</span></p>
 
 <p><span class="c1">; type key 12</span>
@@ -3959,6 +3972,18 @@ because smaller type keys encode on the wire smaller.</p>
     <li><a href="#ref-for-dfn-remote-playback-source">7.5. Remote Playback API</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-section-4.1.1">
+   <a href="https://tools.ietf.org/html/rfc6763#section-4.1.1">https://tools.ietf.org/html/rfc6763#section-4.1.1</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-section-4.1.1">3. Discovery with mDNS</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-section-7">
+   <a href="https://tools.ietf.org/html/rfc6763#section-7">https://tools.ietf.org/html/rfc6763#section-7</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-section-7">3. Discovery with mDNS</a>
+   </ul>
+  </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
@@ -3992,6 +4017,12 @@ because smaller type keys encode on the wire smaller.</p>
      <li><span class="dfn-paneled" id="term-for-dfn-remote-playback-devices" style="color:initial">remote playback devices</span>
      <li><span class="dfn-paneled" id="term-for-dfn-remote-playback-source" style="color:initial">remote playback source</span>
     </ul>
+   <li>
+    <a data-link-type="biblio">[RFC6763]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-section-4.1.1" style="color:initial">instance name</span>
+     <li><span class="dfn-paneled" id="term-for-section-7" style="color:initial">service name</span>
+    </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
@@ -4004,6 +4035,8 @@ because smaller type keys encode on the wire smaller.</p>
    <dd>Mounir Lamouri; Anton Vayvod. <a href="https://www.w3.org/TR/remote-playback/">Remote Playback API</a>. 19 October 2017. CR. URL: <a href="https://www.w3.org/TR/remote-playback/">https://www.w3.org/TR/remote-playback/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-rfc6763">[RFC6763]
+   <dd>S. Cheshire; M. Krochmal. <a href="https://tools.ietf.org/html/rfc6763">DNS-Based Service Discovery</a>. February 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6763">https://tools.ietf.org/html/rfc6763</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -4013,8 +4046,6 @@ because smaller type keys encode on the wire smaller.</p>
    <dd>J. Iyengar; M. Thomson. <a href="https://tools.ietf.org/html/draft-ietf-quic-transport-16">Concise data definition language (CDDL): a notational convention to express CBOR and JSON data structures</a>. 23 October 2018. Internet Draft. URL: <a href="https://tools.ietf.org/html/draft-ietf-quic-transport-16">https://tools.ietf.org/html/draft-ietf-quic-transport-16</a>
    <dt id="biblio-rfc6762">[RFC6762]
    <dd>S. Cheshire; M. Krochmal. <a href="https://tools.ietf.org/html/rfc6762">Multicast DNS</a>. February 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6762">https://tools.ietf.org/html/rfc6762</a>
-   <dt id="biblio-rfc6763">[RFC6763]
-   <dd>S. Cheshire; M. Krochmal. <a href="https://tools.ietf.org/html/rfc6763">DNS-Based Service Discovery</a>. February 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6763">https://tools.ietf.org/html/rfc6763</a>
    <dt id="biblio-rfc7049">[RFC7049]
    <dd>C. Bormann; P. Hoffman. <a href="https://tools.ietf.org/html/rfc7049">Concise Binary Object Representation (CBOR)</a>. October 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7049">https://tools.ietf.org/html/rfc7049</a>
    <dt id="biblio-security-privacy-questionnaire">[SECURITY-PRIVACY-QUESTIONNAIRE]

--- a/index.html
+++ b/index.html
@@ -1029,7 +1029,7 @@ Possible extra rowspan handling
 		}
 	/* } */
 
-	@supports (display:grid) {
+	@supports (display:grid) and (display:contents) {
 		/* Use #toc over .toc to override non-@supports rules. */
 		#toc {
 			display: grid;
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version ee4d7efc3ed6155392d49e10a542e2351fd5792d" name="generator">
+  <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="de573339f57979ede2601a0b9421a68061662a7d" name="document-revision">
+  <meta content="db6056d9460cfd0e00d68d315ce6b720964522ff" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-05-31">31 May 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-06">6 August 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1571,6 +1571,7 @@ pre .property::before, pre .property::after {
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
       <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
      </ol>
     <li>
@@ -1644,7 +1645,7 @@ presentation display connected to the same IPv4 or IPv6 subnet and reachable
 by IP multicast.</p>
     <li data-md>
      <p>A controlling user agent must be able to obtain the IPv4 or IPv6 address of
-the display, a friendly name for the display, and an IP port number for
+the display, a display name for the display, and an IP port number for
 establishing a network transport to the display.</p>
     <li data-md>
      <p>A controlling user agent must be able to determine if the receiver is
@@ -1763,20 +1764,22 @@ specification, to facilitate experimentation and enhancement of the base
 APIs.</p>
    </ol>
    <h2 class="heading settled" data-level="3" id="discovery"><span class="secno">3. </span><span class="content">Discovery with mDNS</span><a class="self-link" href="#discovery"></a></h2>
-   <p>Agents may discover one another using <a data-link-type="biblio" href="#biblio-rfc6763">DNS-SD</a> over <a data-link-type="biblio" href="#biblio-rfc6762">mDNS</a>.
-To do so, agents must use the service name "_openscreen._udp.local".</p>
+   <p>Agents must discover one another using <a data-link-type="biblio" href="#biblio-rfc6763">DNS-SD</a> over <a data-link-type="biblio" href="#biblio-rfc6762">mDNS</a>.
+To do so, agents must use the service name <code>_openscreen._udp.local</code>.</p>
    <p class="issue" id="issue-56c2cd35"><a class="self-link" href="#issue-56c2cd35"></a> Define suspend and resume behavior for discovery protocol. <a href="https://github.com/webscreens/openscreenprotocol/issues/107">&lt;https://github.com/webscreens/openscreenprotocol/issues/107></a></p>
-   <p>Advertising Agents must use an instance name that is a prefix of the agent’s
-display name. If the instance name is not the complete display name (if it has
-been truncated), it must be terminated by a null character.  It is prefix so
-that the name displayed to the user pre-verification can be verified later.  It
-is terminated by a null character in the case of truncation so that the
-listening agent knows it has been truncated.  This complexity is necessary to
-all for display names that exceed the size allowed in an instance name and for
-such (possibly  truncated) display names to be visible to the user sooner
-(before a QUIC connection is made).  Listening agents must treat instance names
-as unverified and must verify that the instance name is a prefix of the verified
-display name before showing the user a verified display name.</p>
+   <p>An <dfn data-dfn-type="dfn" data-noexport id="advertising-agent">advertising agent<a class="self-link" href="#advertising-agent"></a></dfn> is one that responds to mDNS queries
+for <code>_openscreen._udp.local</code>.  Such an agent should have a <dfn data-dfn-type="dfn" data-lt="display name" data-noexport id="display-name">display
+name<a class="self-link" href="#display-name"></a></dfn> (a non-empty string) that is a human readable description of the
+presentation display, e.g. "Living Room TV."</p>
+   <p>A <dfn data-dfn-type="dfn" data-noexport id="listening-agent">listening agent<a class="self-link" href="#listening-agent"></a></dfn> is one that sends mDNS queries for <code>_openscreen._udp.local</code>.  Listening agents may have a display name.</p>
+   <p>Advertising agents must use an DNS-SD instance name that is a prefix of the
+agent’s display name.  If the instance name is not the complete display name, it
+must be terminated by a null (<code>\000</code>) character, so that a listening agent knows
+it has been truncated.  Agents must show only complete display names to the
+user, and never truncated display names.</p>
+   <p>Agents must treat instance names as unverified information, and should check that
+the instance name is a prefix of the display name received through the <code>agent-info</code> message after a successful QUIC connection.  Once an agent has done
+this check, it can show the name as a <dfn data-dfn-type="dfn" data-noexport id="verified-display-name">verified display name<a class="self-link" href="#verified-display-name"></a></dfn>.</p>
    <p>Advertising agents must include DNS TXT records with the following
 keys and values:</p>
    <dl>
@@ -1812,6 +1815,11 @@ it initiates a <a data-link-type="biblio" href="#biblio-quic">[QUIC]</a> connect
 Prior to authentication, a message may be exchanged (such as further metadata),
 but such info should be treated as unverified (such as indicating to a user that
 a display name of an unauthenticated agent is unverified).</p>
+   <p>The connection IDs used both by the <a data-link-type="biblio" href="#biblio-quic">[QUIC]</a> client and server should
+be zero length.  If zero length connection IDs are chosen, agents are
+restricted from changing IP or port without establishing a new QUIC
+connection.  In such cases, clients and servers must establish a new
+QUIC connection in order to change IP or port.</p>
    <p>To learn further metadata, an agent may send an agent-info-request
 message (see <a href="#appendix-a">Appendix A: Messages</a>) and receive back an agent-info-response message.
 Any agent may send this request to learn about the capabilities of
@@ -1828,14 +1836,48 @@ another device.</p>
      <p>If the agent is a hardware device, the model name of
 the device.  This is used mainly for debugging purposes, but may be
 displayed to the user of the requesting agent.</p>
-    <dt data-md>receives-audio (optional)
+    <dt data-md>capabilities (required)
     <dd data-md>
-     <p>The agent has to indicate that it supports audio. If false
-or not included, it is assumed audio content is not supported.</p>
-    <dt data-md>receives-video (optional)
+     <p>The control protocols, roles, and media types the agent supports.
+Presence indicates a capability and absence indicates lack of a
+capability.  Capabilities should should affect how an agent is
+presented to a user, such as drawing a different icon depending on
+the media types it supports.</p>
+   </dl>
+   <p>The various capabilities have the following meanings:</p>
+   <dl>
+    <dt data-md>receive-audio
     <dd data-md>
-     <p>The agent has to indicate that it supports video . If false
-or not included, it is assumed video content is not supported.</p>
+     <p>The agent can generally receive audio for the control protocols it
+supports.  Each control protocol can have more specific capability
+mechanisms, such as support for specific URLs in the presentation
+protocol.</p>
+    <dt data-md>receive-video
+    <dd data-md>
+     <p>The agent can generally receive video for the control protocols it
+supports.  Each control protocol can have more specific capability
+mechanisms, such as support for specific URLs in the presentation
+protocol.</p>
+    <dt data-md>receive-presentation
+    <dd data-md>
+     <p>The agent can receive presentations using the presentation protocol.</p>
+    <dt data-md>control-presentation
+    <dd data-md>
+     <p>The agent can control presentations using the presentation protocol.</p>
+    <dt data-md>receive-remote-playback
+    <dd data-md>
+     <p>The agent can receive remote playback using the remote playback
+protocol.</p>
+    <dt data-md>control-remote-playback
+    <dd data-md>
+     <p>The agent can control remote playback using the remote playback
+protocol.</p>
+    <dt data-md>receive-streaming
+    <dd data-md>
+     <p>The agent can receiving streaming using the streaming protocol.</p>
+    <dt data-md>send-streaming
+    <dd data-md>
+     <p>The agent can send streaming using the streaming protocol.</p>
    </dl>
    <p>Listening agents act as QUIC clients.  Advertising agents act as QUIC servers.</p>
    <p>If a listening agent wishes to receive messages from an advertising agent or an
@@ -1954,7 +1996,7 @@ and sends the auth-status authenticated message.</p>
    <h2 class="heading settled" data-level="7" id="control-protocols"><span class="secno">7. </span><span class="content">Control Protocols</span><a class="self-link" href="#control-protocols"></a></h2>
    <h3 class="heading settled" data-level="7.1" id="presentation-protocol"><span class="secno">7.1. </span><span class="content">Presentation Protocol</span><a class="self-link" href="#presentation-protocol"></a></h3>
    <p>This section defines the use of the Open Screen Protocol for starting,
-terminating, and controlling presentations as defined by <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a>. <a href="#presentation-api">§7.2 Presentation API</a> defines how APIs in <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> map to the
+terminating, and controlling presentations as defined by <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a>. <a href="#presentation-api">§ 7.2 Presentation API</a> defines how APIs in <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> map to the
 protocol messages defined in this section.</p>
    <p>For all messages defined in this section, see <a href="#appendix-a">Appendix A: Messages</a> for the full
 CDDL definitions.</p>
@@ -2140,7 +2182,7 @@ values:</p>
 the user with more explanation as to why it was closed.</p>
    </dl>
    <h3 class="heading settled" data-level="7.2" id="presentation-api"><span class="secno">7.2. </span><span class="content">Presentation API</span><a class="self-link" href="#presentation-api"></a></h3>
-   <p>This section defines how the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> uses the <a href="#presentation-protocol">§7.1 Presentation Protocol</a>.</p>
+   <p>This section defines how the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> uses the <a href="#presentation-protocol">§ 7.1 Presentation Protocol</a>.</p>
    <p>When <a href="https://www.w3.org/TR/presentation-api/#the-list-of-available-presentation-displays">section
 6.4.2</a> says "This list of presentation displays ... is populated based on an
 implementation specific discovery mechanism", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent" id="ref-for-dfn-controlling-user-agent③">controlling user agent</a> may
@@ -2180,7 +2222,7 @@ browsing contexts using an implementation specific mechanism.", the <a data-link
 user agent</a>, must send a presentation-connection-open-response message.</p>
    <h3 class="heading settled" data-level="7.3" id="remote-playback-protocol"><span class="secno">7.3. </span><span class="content">Remote Playback Protocol</span><a class="self-link" href="#remote-playback-protocol"></a></h3>
    <p>This section defines the use of the Open Screen Protocol for starting, terminating,
-and controlling remote playback of media as defined by the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a>. <a href="#remote-playback-api">§7.5 Remote Playback API</a> defines how
+and controlling remote playback of media as defined by the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a>. <a href="#remote-playback-api">§ 7.5 Remote Playback API</a> defines how
 APIs in <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> map to the protocol messages
 defined in this section.</p>
    <p>For all messages defined in this section, see Appendix A for the full
@@ -2268,7 +2310,7 @@ receiver.</p>
     <dt data-md>controls
     <dd data-md>
      <p>Initial controls for modifying the initial state of the remote playback, as
-defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.  The controller may send
+defined in <a href="#remote-playback-state-and-controls">§ 7.4 Remote Playback State and Controls</a>.  The controller may send
 controls that are optional for the receiver to support before it knows the
 receiver supports them.  If the receiver does not support them, it will
 ignore them and the controller will learn that it does not support them from
@@ -2285,7 +2327,7 @@ invalid-url).  Additionally, the response must include the following:</p>
    <dl>
     <dt data-md>state
     <dd data-md>
-     <p>The initial state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.</p>
+     <p>The initial state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§ 7.4 Remote Playback State and Controls</a>.</p>
    </dl>
    <p>If the controller wishes to modify the state of the remote playback (for
 example, to pause, resume, skip, etc), it may send a
@@ -2303,7 +2345,7 @@ remote-playback-modify-response message in reply with the following values:</p>
    <dl>
     <dt data-md>state
     <dd data-md>
-     <p>The updated state of the remote playback as defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.</p>
+     <p>The updated state of the remote playback as defined in <a href="#remote-playback-state-and-controls">§ 7.4 Remote Playback State and Controls</a>.</p>
    </dl>
    <p>When the state of remote playback changes without request for modification from
 the controller (such as when the skips or pauses due to user user interaction on
@@ -2315,7 +2357,7 @@ controller.</p>
      <p>The ID of the remote playback whose state has changed.</p>
     <dt data-md>state
     <dd data-md>
-     <p>The updated state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.</p>
+     <p>The updated state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§ 7.4 Remote Playback State and Controls</a>.</p>
    </dl>
    <p>To terminate the remote playback, the controller may send a
 remote-playback-termination-request message with the following values:</p>
@@ -2536,7 +2578,7 @@ time scales to be expressed without loss of precision.  The scale is represented
 in hertz, such as 90000 for 90000hz, a common time scale for video.</p>
    <h3 class="heading settled" data-level="7.5" id="remote-playback-api"><span class="secno">7.5. </span><span class="content">Remote Playback API</span><a class="self-link" href="#remote-playback-api"></a></h3>
    <p>This section defines how the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> uses the
-messages defined in <a href="#remote-playback-protocol">§7.3 Remote Playback Protocol</a>.</p>
+messages defined in <a href="#remote-playback-protocol">§ 7.3 Remote Playback Protocol</a>.</p>
    <p>When <a href="https://www.w3.org/TR/remote-playback/#the-list-of-available-remote-playback-devices">section
 6.2.1.2</a> says "This list contains remote playback devices and is populated
 based on an implementation specific discovery mechanism" and <a href="https://www.w3.org/TR/remote-playback/#the-list-of-available-remote-playback-devices">section
@@ -2898,7 +2940,7 @@ and/or high value data:</p>
    </ol>
    <p>Presentation IDs are considered high value data because they can be used in
 conjunction with a Presentation URL to connect to a running presentation.</p>
-   <p>Presentation display friendly names, model names, and capabilities, while not
+   <p>Presentation display names, model names, and capabilities, while not
 considered personally identifiable, are important to protect to prevent an
 attacker from changing them or substituting other values during the discovery
 and authentication process.</p>
@@ -2934,7 +2976,7 @@ This prevents Open Screen agents from correlating activity among profiles
 belonging to the same user (both normal and incognito).</p>
    <h4 class="heading settled" data-level="9.2.5" id="persistent-state"><span class="secno">9.2.5. </span><span class="content">Persistent State</span><a class="self-link" href="#persistent-state"></a></h4>
    <p>An agent is likely to persist the identity of agents that have successfully
-completed <a href="#authentication">§6 Authentication</a>.  This may include the public key fingerprints,
+completed <a href="#authentication">§ 6 Authentication</a>.  This may include the public key fingerprints,
 metadata versions, and metadata for those parties.</p>
    <p>However, this data is not normally exposed to the Web, only through the native
 UI of the user agent during the display selection or display authentication
@@ -3003,7 +3045,7 @@ cryptographic parameters of the TLS 1.3 QUIC connection.</p>
    <p class="issue" id="issue-84520e29"><a class="self-link" href="#issue-84520e29"></a> Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a></p>
    <h4 class="heading settled" data-level="9.5.2" id="local-active-mitigations"><span class="secno">9.5.2. </span><span class="content">Local active network attackers</span><a class="self-link" href="#local-active-mitigations"></a></h4>
    <p>Local active attackers may attempt to impersonate a presentation display the
-user would normally trust.  The <a href="#authentication">§6 Authentication</a> step of the Open Screen
+user would normally trust.  The <a href="#authentication">§ 6 Authentication</a> step of the Open Screen
 Protocol prevents a man-in-the-middle from impersonating an agent, without
 knowledge of a shared secret.  However, it is possible for an attacker to
 impersonate an existing, trusted display or a newly discovered display that is
@@ -3016,12 +3058,12 @@ should be flagged include:</p>
      <p>Untrusted agents whose public key fingerprint collides with that from an
 already-trusted agent that is concurrently being advertised.</p>
     <li data-md>
-     <p>Untrusted agents whose friendly name differs from the one previously
+     <p>Untrusted agents whose display name differs from the one previously
 advertised under a given public key fingerprint.</p>
     <li data-md>
      <p>Untrusted agents that fail the authentication challenge a certain number of times.</p>
     <li data-md>
-     <p>Untrusted agents that advertise a friendly name that is similar to that from an
+     <p>Untrusted agents that advertise a display name that is similar to that from an
 already-trusted agent.</p>
     <li data-md>
      <p>Already-trusted agents whose metadata provided through the <code>agent-info</code> message has changed.</p>
@@ -3770,6 +3812,13 @@ because smaller type keys encode on the wire smaller.</p>
 })();
 </script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="index">
+   <li><a href="#advertising-agent">advertising agent</a><span>, in §3</span>
+   <li><a href="#display-name">display name</a><span>, in §3</span>
+   <li><a href="#listening-agent">listening agent</a><span>, in §3</span>
+   <li><a href="#verified-display-name">verified display name</a><span>, in §3</span>
+  </ul>
   <aside class="dfn-panel" data-for="term-for-htmlmediaelement">
    <a href="https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement">https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement</a><b>Referenced in:</b>
    <ul>
@@ -3957,7 +4006,7 @@ because smaller type keys encode on the wire smaller.</p>
    <dt id="biblio-rfc7049">[RFC7049]
    <dd>C. Bormann; P. Hoffman. <a href="https://tools.ietf.org/html/rfc7049">Concise Binary Object Representation (CBOR)</a>. October 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7049">https://tools.ietf.org/html/rfc7049</a>
    <dt id="biblio-security-privacy-questionnaire">[SECURITY-PRIVACY-QUESTIONNAIRE]
-   <dd>Mike West. <a href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire: Security and Privacy</a>. 10 December 2015. NOTE. URL: <a href="https://www.w3.org/TR/security-privacy-questionnaire/">https://www.w3.org/TR/security-privacy-questionnaire/</a>
+   <dd>Lukasz Olejnik; Jason Novak. <a href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire: Security and Privacy</a>. 23 May 2019. NOTE. URL: <a href="https://www.w3.org/TR/security-privacy-questionnaire/">https://www.w3.org/TR/security-privacy-questionnaire/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="db6056d9460cfd0e00d68d315ce6b720964522ff" name="document-revision">
+  <meta content="5a073d21fafe614cb4571349eeadf19bc25fd5dd" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1775,11 +1775,23 @@ presentation display, e.g. "Living Room TV."</p>
    <p>Advertising agents must use an DNS-SD instance name that is a prefix of the
 agent’s display name.  If the instance name is not the complete display name, it
 must be terminated by a null (<code>\000</code>) character, so that a listening agent knows
-it has been truncated.  Agents must show only complete display names to the
-user, and never truncated display names.</p>
-   <p>Agents must treat instance names as unverified information, and should check that
-the instance name is a prefix of the display name received through the <code>agent-info</code> message after a successful QUIC connection.  Once an agent has done
-this check, it can show the name as a <dfn data-dfn-type="dfn" data-noexport id="verified-display-name">verified display name<a class="self-link" href="#verified-display-name"></a></dfn>.</p>
+it has been truncated.</p>
+   <p>Agents must treat instance names as unverified information, and should check
+that the instance name is a prefix of the display name received through the <code>agent-info</code> message after a successful QUIC connection.  Once an agent has done
+this check, it can show the name as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="verified-display-name">verified display name</dfn>.</p>
+   <p>Agents should show only complete display names to the user, instead of truncated
+display names from DNS-SD.  A truncated display name should be verified as above
+before being shown in full as a <a data-link-type="dfn" href="#verified-display-name" id="ref-for-verified-display-name">verified display name</a>.</p>
+   <div class="note" role="note">
+     This means there are three categories of display names that agents should be
+capable of handling: 
+    <ol>
+     <li>Truncated and unverified DNS-SD instance names, which should not be shown to the user.
+     <li>Complete but unverified DNS-SD instance names, which can be shown as
+     unverified prior to <a href="#authentication">§ 6 Authentication</a>.
+     <li>Verified display names.
+    </ol>
+   </div>
    <p>Advertising agents must include DNS TXT records with the following
 keys and values:</p>
    <dl>
@@ -4039,6 +4051,12 @@ implementation specific mechanism, quote that here and map it to a message.<a hr
    <div class="issue"> Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a><a href="#issue-84520e29①"> ↵ </a></div>
    <div class="issue"> Mitigations for remote network attackers. <a href="https://github.com/webscreens/openscreenprotocol/issues/131">&lt;https://github.com/webscreens/openscreenprotocol/issues/131></a><a href="#issue-7e863472"> ↵ </a></div>
   </div>
+  <aside class="dfn-panel" data-for="verified-display-name">
+   <b><a href="#verified-display-name">#verified-display-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-verified-display-name">3. Discovery with mDNS</a>
+   </ul>
+  </aside>
 <script>/* script-dfn-panel */
 
 document.body.addEventListener("click", function(e) {

--- a/messages_appendix.html
+++ b/messages_appendix.html
@@ -9,11 +9,24 @@
 <span class="nx">  1</span><span class="p">:</span> <span class="nx">agent-info </span><span class="c1">; agent-info</span>
 <span class="p">}</span>
 
+<span class="nx">agent-capability </span><span class="p">=</span> <span class="o">&amp;</span><span class="p">(</span>
+  <span class="nx">receive-audio</span><span class="p">:</span> <span class="mi">1</span>
+  <span class="nx">receive-video</span><span class="p">:</span> <span class="mi">2</span>
+
+  <span class="nx">receive-presentation</span><span class="p">:</span> <span class="mi">2</span>
+  <span class="nx">control-presentation</span><span class="p">:</span> <span class="mi">3</span>
+
+  <span class="nx">receive-remote-playback</span><span class="p">:</span> <span class="mi">4</span>
+  <span class="nx">control-remote-playback</span><span class="p">:</span> <span class="mi">5</span>
+
+  <span class="nx">receive-streaming</span><span class="p">:</span> <span class="mi">6</span>
+  <span class="nx">send-streaming</span><span class="p">:</span> <span class="mi">7</span>
+<span class="p">)</span>
+
 <span class="nx">agent-info </span><span class="p">=</span> <span class="p">{</span>
   <span class="mi">0</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; display-name</span>
   <span class="mi">1</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; model-name</span>
-  <span class="p">?</span> <span class="mi">2</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; receives-audio</span>
-  <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">bool </span><span class="c1">; receives-video</span>
+  <span class="mi">2</span><span class="p">:</span> <span class="p">[</span><span class="o">*</span> <span class="nx">agent-capabilitiy</span><span class="p">]</span> <span class="c1">; capabilities</span>
 <span class="p">}</span>
 
 <span class="c1">; type key 12</span>


### PR DESCRIPTION
This is a followup to https://github.com/webscreens/openscreenprotocol/pull/179.

It makes the following changes:
- Adds definitions for advertising agent, listening agent, display name, verified display name.
- Clarifies that truncated display names must never be shown to users.
- Clarifies that prefix check is required before the display name is verified.
- Replaced usages of "friendly name" with "display name."  (I could go through and autolink these usages if folks like, but maybe adding autolinks across the spec is better done in a separate PR.)
- Makes the usage of mDNS/DNS-SD a "must." This seems non-controversial to me, as it's the only discovery mechanism at present, but happy to do this in a separate PR if folks want to discuss.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/pull/180.html" title="Last updated on Aug 13, 2019, 5:53 PM UTC (3cea78b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/180/b72ed9f...3cea78b.html" title="Last updated on Aug 13, 2019, 5:53 PM UTC (3cea78b)">Diff</a>