### PR TITLE
Allocation of request and watch IDs.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -346,12 +346,13 @@ restricted from changing IP or port without establishing a new QUIC
 connection.  In such cases, clients and servers must establish a new
 QUIC connection in order to change IP or port.
 
-To learn further metadata, an agent may send an agent-info-request
-message (see [[#appendix-a]]) and receive back an agent-info-response message.
-Any agent may send this request to learn about the capabilities of
-another device.
+To learn further metadata, an agent may send an agent-info-request message (see
+[[#appendix-a]]) and receive back an agent-info-response message.  Any agent may
+send this request at any time to learn about the state and capabilities of
+another device, which are described by the `agent-info` message in the
+`agent-info-response`.
 
-The agent-info-response message contains the following properties:
+The `agent-info` message contains the following properties:
 
 : display-name (required)
 :: The display name of the agent, intended to be displayed to a user by the
@@ -369,6 +370,12 @@ The agent-info-response message contains the following properties:
     capability.  Capabilities should should affect how an agent is
     presented to a user, such as drawing a different icon depending on
     the media types it supports.
+
+: state-token (required)
+:: A random alphanumeric value consisting of 8 characters in the range
+    [0-9A-Za-z].  This value is set before the agent makes its first connection
+    and must be set to a new value when the agent is reset or otherwise lost all
+    of its state related to this protocol.
 
 The various capabilities have the following meanings:
 
@@ -577,10 +584,7 @@ presentation-url-availability-request message with the following values:
 : watch-id
 :: An identifier the receiver must use when sending updates about URL
     availability so that the controller knows which URLs the receiver is referring
-    to.  The controller must choose a value that is unique across all
-    presentation URL availability watches to the same receiver.
-
-Issue(145): Watch ID Uniqueness.
+    to.
 
 In response, the receiver should send one presentation-url-availability-response
 message with the following values:
@@ -610,11 +614,7 @@ availability request.
 To save power, the controller may disconnect the QUIC connection and
 later reconnect to send availability requests and receive availability
 responses and updates.  The QUIC connection ID may or may not be the same
-when reconnecting.  Note that the lifetime of a watch-id is not limited
-to one QUIC connection.  The receiver must continue sending updates for watches
-even if the QUIC connection changes, and thus controller need not send
-new URL availability requests if the QUIC connection changes.
-
+when reconnecting.
 
 To start a presentation, the controller may send a
 presentation-start-request message to the receiver with the following
@@ -844,8 +844,7 @@ Issue(146): Remote Playback HTTP headers.
 : watch-id
 :: An identifier the receiver must use when sending updates about URL
     availability so that the controller knows which URLs the receiver is referring
-    to. The controller must choose a value that is unique across all
-    remote playback availability watches to the same receiver.
+    to.
 
 In response, the receiver should send a remote-playback-availability-response
 message with the following values:
@@ -875,11 +874,7 @@ availability request.
 To save power, the controller may disconnect the QUIC connection and
 later reconnect to send availability requests and receive availability
 responses and updates. The QUIC connection ID may or may not be the same
-when reconnecting.  Note that the lifetime of a watch-id is not limited
-to one QUIC connection.  The receiver must continue sending updates for watches
-even if the QUIC connection changes, and thus controller need not send
-new URL availability requests if the QUIC connection changes.
-
+when reconnecting.
 
 To start remote playback, the controller may send a
 remote-playback-start-request message to the receiver with the following
@@ -1562,6 +1557,32 @@ Stats {#streaming-stats}
 
 TODO
 
+Requests, Responses, and Watches {#requests-responses--watches}
+===============================================================
+
+Multiple sub-protocols in OSP have messages that act as requests, responses,
+watches, and events. Most requests have a `request-id`, and the agent that
+receives the request must send exactly one reponse message in return with the
+same `request-id`.  A watch request has a `watch-id`, and the agent that
+receives the request may send any number of event messages in response with
+the same `watch-id`, until the watch request expires.
+
+`request-id` and `watch-id` values are unsigned integer IDs that are assigned
+from a counter kept by each agent that starts at 1 and increments by 1 for each
+ID.  Whenever an agent changes its `state-token`, it must reset its counter to 1.
+
+When an agent sees that another agent has reset its state (by virtue of
+advertising a new `state-token`), it should discard any requests, responses,
+watches and events for that agent.
+
+Note: Request and watch IDs are not tied to any particular QUIC connection
+between agents.  If a QUIC connection is closed, an agent should not discard
+requests, responses, watches, or events related to the other party.  This allows
+agents to save power by closing unused connections.
+
+Note: Request and watch IDs are not unique across agents.  An agent can combine
+a request ID with a unique identifier for the agent that sent it (like its
+certificate fingerprint) to track requests across multiple agents.
 
 Security and Privacy {#security-privacy}
 ====================

--- a/index.html
+++ b/index.html
@@ -1029,7 +1029,7 @@ Possible extra rowspan handling
 		}
 	/* } */
 
-	@supports (display:grid) {
+	@supports (display:grid) and (display:contents) {
 		/* Use #toc over .toc to override non-@supports rules. */
 		#toc {
 			display: grid;
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version ee4d7efc3ed6155392d49e10a542e2351fd5792d" name="generator">
+  <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="de573339f57979ede2601a0b9421a68061662a7d" name="document-revision">
+  <meta content="db6056d9460cfd0e00d68d315ce6b720964522ff" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-05-31">31 May 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-08">8 August 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1533,37 +1533,38 @@ pre .property::before, pre .property::after {
       <li><a href="#streaming-feedback"><span class="secno">8.6</span> <span class="content">Feedback</span></a>
       <li><a href="#streaming-stats"><span class="secno">8.7</span> <span class="content">Stats</span></a>
      </ol>
+    <li><a href="#requests-responses--watches"><span class="secno">9</span> <span class="content">Requests, Responses, and Watches</span></a>
     <li>
-     <a href="#security-privacy"><span class="secno">9</span> <span class="content">Security and Privacy</span></a>
+     <a href="#security-privacy"><span class="secno">10</span> <span class="content">Security and Privacy</span></a>
      <ol class="toc">
       <li>
-       <a href="#threat-models"><span class="secno">9.1</span> <span class="content">Threat Models</span></a>
+       <a href="#threat-models"><span class="secno">10.1</span> <span class="content">Threat Models</span></a>
        <ol class="toc">
-        <li><a href="#passive-network-attackers"><span class="secno">9.1.1</span> <span class="content">Passive Network Attackers</span></a>
-        <li><a href="#active-network-attackers"><span class="secno">9.1.2</span> <span class="content">Active Network Attackers</span></a>
-        <li><a href="#denial-of-service"><span class="secno">9.1.3</span> <span class="content">Denial of Service</span></a>
-        <li><a href="#same-origin-policy-violations"><span class="secno">9.1.4</span> <span class="content">Same-Origin Policy Violations</span></a>
+        <li><a href="#passive-network-attackers"><span class="secno">10.1.1</span> <span class="content">Passive Network Attackers</span></a>
+        <li><a href="#active-network-attackers"><span class="secno">10.1.2</span> <span class="content">Active Network Attackers</span></a>
+        <li><a href="#denial-of-service"><span class="secno">10.1.3</span> <span class="content">Denial of Service</span></a>
+        <li><a href="#same-origin-policy-violations"><span class="secno">10.1.4</span> <span class="content">Same-Origin Policy Violations</span></a>
        </ol>
       <li>
-       <a href="#security-privacy-questions"><span class="secno">9.2</span> <span class="content">Open Screen Protocol Security and Privacy Considerations</span></a>
+       <a href="#security-privacy-questions"><span class="secno">10.2</span> <span class="content">Open Screen Protocol Security and Privacy Considerations</span></a>
        <ol class="toc">
-        <li><a href="#personally-identifiable-information"><span class="secno">9.2.1</span> <span class="content">Personally Identifiable Information &amp; High-Value Data</span></a>
-        <li><a href="#cross-origin-state"><span class="secno">9.2.2</span> <span class="content">Cross Origin State Considerations</span></a>
-        <li><a href="#origin-access-devices"><span class="secno">9.2.3</span> <span class="content">Origin Access to Other Devices</span></a>
-        <li><a href="#incognito-mode"><span class="secno">9.2.4</span> <span class="content">Incognito Mode</span></a>
-        <li><a href="#persistent-state"><span class="secno">9.2.5</span> <span class="content">Persistent State</span></a>
-        <li><a href="#other-considerations"><span class="secno">9.2.6</span> <span class="content">Other Considerations</span></a>
+        <li><a href="#personally-identifiable-information"><span class="secno">10.2.1</span> <span class="content">Personally Identifiable Information &amp; High-Value Data</span></a>
+        <li><a href="#cross-origin-state"><span class="secno">10.2.2</span> <span class="content">Cross Origin State Considerations</span></a>
+        <li><a href="#origin-access-devices"><span class="secno">10.2.3</span> <span class="content">Origin Access to Other Devices</span></a>
+        <li><a href="#incognito-mode"><span class="secno">10.2.4</span> <span class="content">Incognito Mode</span></a>
+        <li><a href="#persistent-state"><span class="secno">10.2.5</span> <span class="content">Persistent State</span></a>
+        <li><a href="#other-considerations"><span class="secno">10.2.6</span> <span class="content">Other Considerations</span></a>
        </ol>
-      <li><a href="#presentation-api-considerations"><span class="secno">9.3</span> <span class="content">Presentation API Considerations</span></a>
-      <li><a href="#remote-playback-considerations"><span class="secno">9.4</span> <span class="content">Remote Playback API Considerations</span></a>
+      <li><a href="#presentation-api-considerations"><span class="secno">10.3</span> <span class="content">Presentation API Considerations</span></a>
+      <li><a href="#remote-playback-considerations"><span class="secno">10.4</span> <span class="content">Remote Playback API Considerations</span></a>
       <li>
-       <a href="#security-mitigations"><span class="secno">9.5</span> <span class="content">Mitigation Strategies</span></a>
+       <a href="#security-mitigations"><span class="secno">10.5</span> <span class="content">Mitigation Strategies</span></a>
        <ol class="toc">
-        <li><a href="#local-passive-mitigations"><span class="secno">9.5.1</span> <span class="content">Local passive network attackers</span></a>
-        <li><a href="#local-active-mitigations"><span class="secno">9.5.2</span> <span class="content">Local active network attackers</span></a>
-        <li><a href="#remote-active-mitigations"><span class="secno">9.5.3</span> <span class="content">Remote active network attackers</span></a>
-        <li><a href="#denial-of-service-mitigations"><span class="secno">9.5.4</span> <span class="content">Denial of service</span></a>
-        <li><a href="#malicious-input-mitigations"><span class="secno">9.5.5</span> <span class="content">Malicious input</span></a>
+        <li><a href="#local-passive-mitigations"><span class="secno">10.5.1</span> <span class="content">Local passive network attackers</span></a>
+        <li><a href="#local-active-mitigations"><span class="secno">10.5.2</span> <span class="content">Local active network attackers</span></a>
+        <li><a href="#remote-active-mitigations"><span class="secno">10.5.3</span> <span class="content">Remote active network attackers</span></a>
+        <li><a href="#denial-of-service-mitigations"><span class="secno">10.5.4</span> <span class="content">Denial of service</span></a>
+        <li><a href="#malicious-input-mitigations"><span class="secno">10.5.5</span> <span class="content">Malicious input</span></a>
        </ol>
      </ol>
     <li><a href="#appendix-a"><span class="secno"></span> <span class="content">Appendix A: Messages</span></a>
@@ -1777,6 +1778,8 @@ such (possibly  truncated) display names to be visible to the user sooner
 (before a QUIC connection is made).  Listening agents must treat instance names
 as unverified and must verify that the instance name is a prefix of the verified
 display name before showing the user a verified display name.</p>
+   <p>Agents should use the complete display name to the user rather than a
+truncated display name.</p>
    <p>Advertising agents must include DNS TXT records with the following
 keys and values:</p>
    <dl>
@@ -1812,11 +1815,15 @@ it initiates a <a data-link-type="biblio" href="#biblio-quic">[QUIC]</a> connect
 Prior to authentication, a message may be exchanged (such as further metadata),
 but such info should be treated as unverified (such as indicating to a user that
 a display name of an unauthenticated agent is unverified).</p>
-   <p>To learn further metadata, an agent may send an agent-info-request
-message (see <a href="#appendix-a">Appendix A: Messages</a>) and receive back an agent-info-response message.
-Any agent may send this request to learn about the capabilities of
-another device.</p>
-   <p>The agent-info-response message contains the following properties:</p>
+   <p>The connection IDs used both by the <a data-link-type="biblio" href="#biblio-quic">[QUIC]</a> client and server should
+be zero length.  If zero length connection IDs are chosen, agents are
+restricted from changing IP or port without establishing a new QUIC
+connection.  In such cases, clients and servers must establish a new
+QUIC connection in order to change IP or port.</p>
+   <p>To learn further metadata, an agent may send an agent-info-request message (see <a href="#appendix-a">Appendix A: Messages</a>) and receive back an agent-info-response message.  Any agent may
+send this request at any time to learn about the state and capabilities of
+another device, which are described by the <code>agent-info</code> message in the <code>agent-info-response</code>.</p>
+   <p>The <code>agent-info</code> message contains the following properties:</p>
    <dl>
     <dt data-md>display-name (required)
     <dd data-md>
@@ -1828,14 +1835,54 @@ another device.</p>
      <p>If the agent is a hardware device, the model name of
 the device.  This is used mainly for debugging purposes, but may be
 displayed to the user of the requesting agent.</p>
-    <dt data-md>receives-audio (optional)
+    <dt data-md>capabilities (required)
     <dd data-md>
-     <p>The agent has to indicate that it supports audio. If false
-or not included, it is assumed audio content is not supported.</p>
-    <dt data-md>receives-video (optional)
+     <p>The control protocols, roles, and media types the agent supports.
+Presence indicates a capability and absence indicates lack of a
+capability.  Capabilities should should affect how an agent is
+presented to a user, such as drawing a different icon depending on
+the media types it supports.</p>
+    <dt data-md>state-token (required)
     <dd data-md>
-     <p>The agent has to indicate that it supports video . If false
-or not included, it is assumed video content is not supported.</p>
+     <p>A random alphanumeric value consisting of 8 characters in the range
+[0-9A-Za-z].  This value is set before the agent makes its first connection
+and must be set to a new value when the agent is reset or otherwise lost all
+of its state related to this protocol.</p>
+   </dl>
+   <p>The various capabilities have the following meanings:</p>
+   <dl>
+    <dt data-md>receive-audio
+    <dd data-md>
+     <p>The agent can generally receive audio for the control protocols it
+supports.  Each control protocol can have more specific capability
+mechanisms, such as support for specific URLs in the presentation
+protocol.</p>
+    <dt data-md>receive-video
+    <dd data-md>
+     <p>The agent can generally receive video for the control protocols it
+supports.  Each control protocol can have more specific capability
+mechanisms, such as support for specific URLs in the presentation
+protocol.</p>
+    <dt data-md>receive-presentation
+    <dd data-md>
+     <p>The agent can receive presentations using the presentation protocol.</p>
+    <dt data-md>control-presentation
+    <dd data-md>
+     <p>The agent can control presentations using the presentation protocol.</p>
+    <dt data-md>receive-remote-playback
+    <dd data-md>
+     <p>The agent can receive remote playback using the remote playback
+protocol.</p>
+    <dt data-md>control-remote-playback
+    <dd data-md>
+     <p>The agent can control remote playback using the remote playback
+protocol.</p>
+    <dt data-md>receive-streaming
+    <dd data-md>
+     <p>The agent can receiving streaming using the streaming protocol.</p>
+    <dt data-md>send-streaming
+    <dd data-md>
+     <p>The agent can send streaming using the streaming protocol.</p>
    </dl>
    <p>Listening agents act as QUIC clients.  Advertising agents act as QUIC servers.</p>
    <p>If a listening agent wishes to receive messages from an advertising agent or an
@@ -1954,7 +2001,7 @@ and sends the auth-status authenticated message.</p>
    <h2 class="heading settled" data-level="7" id="control-protocols"><span class="secno">7. </span><span class="content">Control Protocols</span><a class="self-link" href="#control-protocols"></a></h2>
    <h3 class="heading settled" data-level="7.1" id="presentation-protocol"><span class="secno">7.1. </span><span class="content">Presentation Protocol</span><a class="self-link" href="#presentation-protocol"></a></h3>
    <p>This section defines the use of the Open Screen Protocol for starting,
-terminating, and controlling presentations as defined by <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a>. <a href="#presentation-api">§7.2 Presentation API</a> defines how APIs in <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> map to the
+terminating, and controlling presentations as defined by <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a>. <a href="#presentation-api">§ 7.2 Presentation API</a> defines how APIs in <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> map to the
 protocol messages defined in this section.</p>
    <p>For all messages defined in this section, see <a href="#appendix-a">Appendix A: Messages</a> for the full
 CDDL definitions.</p>
@@ -1975,10 +2022,8 @@ about their URLs, should the availability change.</p>
     <dd data-md>
      <p>An identifier the receiver must use when sending updates about URL
 availability so that the controller knows which URLs the receiver is referring
-to.  The controller must choose a value that is unique across all
-presentation URL availability watches to the same receiver.</p>
+to.</p>
    </dl>
-   <p class="issue" id="issue-23b856c4"><a class="self-link" href="#issue-23b856c4"></a> Watch ID Uniqueness. <a href="https://github.com/webscreens/openscreenprotocol/issues/145">&lt;https://github.com/webscreens/openscreenprotocol/issues/145></a></p>
    <p>In response, the receiver should send one presentation-url-availability-response
 message with the following values:</p>
    <dl>
@@ -2007,10 +2052,7 @@ availability request.</p>
    <p>To save power, the controller may disconnect the QUIC connection and
 later reconnect to send availability requests and receive availability
 responses and updates.  The QUIC connection ID may or may not be the same
-when reconnecting.  Note that the lifetime of a watch-id is not limited
-to one QUIC connection.  The receiver must continue sending updates for watches
-even if the QUIC connection changes, and thus controller need not send
-new URL availability requests if the QUIC connection changes.</p>
+when reconnecting.</p>
    <p>To start a presentation, the controller may send a
 presentation-start-request message to the receiver with the following
 values:</p>
@@ -2140,7 +2182,7 @@ values:</p>
 the user with more explanation as to why it was closed.</p>
    </dl>
    <h3 class="heading settled" data-level="7.2" id="presentation-api"><span class="secno">7.2. </span><span class="content">Presentation API</span><a class="self-link" href="#presentation-api"></a></h3>
-   <p>This section defines how the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> uses the <a href="#presentation-protocol">§7.1 Presentation Protocol</a>.</p>
+   <p>This section defines how the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> uses the <a href="#presentation-protocol">§ 7.1 Presentation Protocol</a>.</p>
    <p>When <a href="https://www.w3.org/TR/presentation-api/#the-list-of-available-presentation-displays">section
 6.4.2</a> says "This list of presentation displays ... is populated based on an
 implementation specific discovery mechanism", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent" id="ref-for-dfn-controlling-user-agent③">controlling user agent</a> may
@@ -2180,7 +2222,7 @@ browsing contexts using an implementation specific mechanism.", the <a data-link
 user agent</a>, must send a presentation-connection-open-response message.</p>
    <h3 class="heading settled" data-level="7.3" id="remote-playback-protocol"><span class="secno">7.3. </span><span class="content">Remote Playback Protocol</span><a class="self-link" href="#remote-playback-protocol"></a></h3>
    <p>This section defines the use of the Open Screen Protocol for starting, terminating,
-and controlling remote playback of media as defined by the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a>. <a href="#remote-playback-api">§7.5 Remote Playback API</a> defines how
+and controlling remote playback of media as defined by the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a>. <a href="#remote-playback-api">§ 7.5 Remote Playback API</a> defines how
 APIs in <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> map to the protocol messages
 defined in this section.</p>
    <p>For all messages defined in this section, see Appendix A for the full
@@ -2213,8 +2255,7 @@ about their URLs, should the availability change.</p>
     <dd data-md>
      <p>An identifier the receiver must use when sending updates about URL
 availability so that the controller knows which URLs the receiver is referring
-to. The controller must choose a value that is unique across all
-remote playback availability watches to the same receiver.</p>
+to.</p>
    </dl>
    <p>In response, the receiver should send a remote-playback-availability-response
 message with the following values:</p>
@@ -2244,10 +2285,7 @@ availability request.</p>
    <p>To save power, the controller may disconnect the QUIC connection and
 later reconnect to send availability requests and receive availability
 responses and updates. The QUIC connection ID may or may not be the same
-when reconnecting.  Note that the lifetime of a watch-id is not limited
-to one QUIC connection.  The receiver must continue sending updates for watches
-even if the QUIC connection changes, and thus controller need not send
-new URL availability requests if the QUIC connection changes.</p>
+when reconnecting.</p>
    <p>To start remote playback, the controller may send a
 remote-playback-start-request message to the receiver with the following
 values:</p>
@@ -2268,7 +2306,7 @@ receiver.</p>
     <dt data-md>controls
     <dd data-md>
      <p>Initial controls for modifying the initial state of the remote playback, as
-defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.  The controller may send
+defined in <a href="#remote-playback-state-and-controls">§ 7.4 Remote Playback State and Controls</a>.  The controller may send
 controls that are optional for the receiver to support before it knows the
 receiver supports them.  If the receiver does not support them, it will
 ignore them and the controller will learn that it does not support them from
@@ -2285,7 +2323,7 @@ invalid-url).  Additionally, the response must include the following:</p>
    <dl>
     <dt data-md>state
     <dd data-md>
-     <p>The initial state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.</p>
+     <p>The initial state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§ 7.4 Remote Playback State and Controls</a>.</p>
    </dl>
    <p>If the controller wishes to modify the state of the remote playback (for
 example, to pause, resume, skip, etc), it may send a
@@ -2303,7 +2341,7 @@ remote-playback-modify-response message in reply with the following values:</p>
    <dl>
     <dt data-md>state
     <dd data-md>
-     <p>The updated state of the remote playback as defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.</p>
+     <p>The updated state of the remote playback as defined in <a href="#remote-playback-state-and-controls">§ 7.4 Remote Playback State and Controls</a>.</p>
    </dl>
    <p>When the state of remote playback changes without request for modification from
 the controller (such as when the skips or pauses due to user user interaction on
@@ -2315,7 +2353,7 @@ controller.</p>
      <p>The ID of the remote playback whose state has changed.</p>
     <dt data-md>state
     <dd data-md>
-     <p>The updated state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§7.4 Remote Playback State and Controls</a>.</p>
+     <p>The updated state of the remote playback, as defined in <a href="#remote-playback-state-and-controls">§ 7.4 Remote Playback State and Controls</a>.</p>
    </dl>
    <p>To terminate the remote playback, the controller may send a
 remote-playback-termination-request message with the following values:</p>
@@ -2536,7 +2574,7 @@ time scales to be expressed without loss of precision.  The scale is represented
 in hertz, such as 90000 for 90000hz, a common time scale for video.</p>
    <h3 class="heading settled" data-level="7.5" id="remote-playback-api"><span class="secno">7.5. </span><span class="content">Remote Playback API</span><a class="self-link" href="#remote-playback-api"></a></h3>
    <p>This section defines how the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> uses the
-messages defined in <a href="#remote-playback-protocol">§7.3 Remote Playback Protocol</a>.</p>
+messages defined in <a href="#remote-playback-protocol">§ 7.3 Remote Playback Protocol</a>.</p>
    <p>When <a href="https://www.w3.org/TR/remote-playback/#the-list-of-available-remote-playback-devices">section
 6.2.1.2</a> says "This list contains remote playback devices and is populated
 based on an implementation specific discovery mechanism" and <a href="https://www.w3.org/TR/remote-playback/#the-list-of-available-remote-playback-devices">section
@@ -2824,7 +2862,27 @@ frame.  If not set, the sender must generate an indepdendent (key) frame.</p>
    </dl>
    <h3 class="heading settled" data-level="8.7" id="streaming-stats"><span class="secno">8.7. </span><span class="content">Stats</span><a class="self-link" href="#streaming-stats"></a></h3>
    <p>TODO</p>
-   <h2 class="heading settled" data-level="9" id="security-privacy"><span class="secno">9. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security-privacy"></a></h2>
+   <h2 class="heading settled" data-level="9" id="requests-responses--watches"><span class="secno">9. </span><span class="content">Requests, Responses, and Watches</span><a class="self-link" href="#requests-responses--watches"></a></h2>
+   <p>Multiple sub-protocols in OSP have messages that act as requests, responses,
+watches, and events. Most requests have a <code>request-id</code>, and the agent that
+receives the request must send exactly one reponse message in return with the
+same <code>request-id</code>.  A watch request has a <code>watch-id</code>, and the agent that
+receives the request may send any number of event messages in response with
+the same <code>watch-id</code>, until the watch request expires.</p>
+   <p><code>request-id</code> and <code>watch-id</code> values are unsigned integer IDs that are assigned
+from a counter kept by each agent that starts at 1 and increments by 1 for each
+ID.  Whenever an agent changes its <code>state-token</code>, it must reset its counter to 1.</p>
+   <p>When an agent sees that another agent has reset its state (by virtue of
+advertising a new <code>state-token</code>), it should discard any requests, responses,
+watches and events for that agent.</p>
+   <p class="note" role="note"><span>Note:</span> Request and watch IDs are not tied to any particular QUIC connection
+between agents.  If a QUIC connection is closed, an agent should not discard
+requests, responses, watches, or events related to the other party.  This allows
+agents to save power by closing unused connections.</p>
+   <p class="note" role="note"><span>Note:</span> Request and watch IDs are not unique across agents.  An agent can combine
+a request ID with a unique identifier for the agent that sent it (like its
+certificate fingerprint) to track requests across multiple agents.</p>
+   <h2 class="heading settled" data-level="10" id="security-privacy"><span class="secno">10. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security-privacy"></a></h2>
    <p>The Open Screen Protocol allows two networked agents to discover each other
 and exchange user and application data.  As such, its security and privacy
 considerations should be closely examined.  We first evaluate the protocol
@@ -2833,8 +2891,8 @@ Questionnaire</a>.  We then examine whether the security and privacy guidelines
 recommended by the <a data-link-type="biblio" href="#biblio-presentation-api">Presentation API</a> and the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a> are met.  Finally we discuss recommended
 mitigations that agents can use to meet these security and privacy
 requirements.</p>
-   <h3 class="heading settled" data-level="9.1" id="threat-models"><span class="secno">9.1. </span><span class="content">Threat Models</span><a class="self-link" href="#threat-models"></a></h3>
-   <h4 class="heading settled" data-level="9.1.1" id="passive-network-attackers"><span class="secno">9.1.1. </span><span class="content">Passive Network Attackers</span><a class="self-link" href="#passive-network-attackers"></a></h4>
+   <h3 class="heading settled" data-level="10.1" id="threat-models"><span class="secno">10.1. </span><span class="content">Threat Models</span><a class="self-link" href="#threat-models"></a></h3>
+   <h4 class="heading settled" data-level="10.1.1" id="passive-network-attackers"><span class="secno">10.1.1. </span><span class="content">Passive Network Attackers</span><a class="self-link" href="#passive-network-attackers"></a></h4>
    <p>The Open Screen Protocol should assume that all parties that are connected to
 the same LAN, either through a wired connection or through WiFi, are able to
 observe all data flowing between Open Screen Protocol agents.</p>
@@ -2842,7 +2900,7 @@ observe all data flowing between Open Screen Protocol agents.</p>
 messages, such as mDNS records and the QUIC handshakes.</p>
    <p>These parties may attempt to learn cryptographic parameters by observing data
 flows on the QUIC connection, or by observing cryptographic timing.</p>
-   <h4 class="heading settled" data-level="9.1.2" id="active-network-attackers"><span class="secno">9.1.2. </span><span class="content">Active Network Attackers</span><a class="self-link" href="#active-network-attackers"></a></h4>
+   <h4 class="heading settled" data-level="10.1.2" id="active-network-attackers"><span class="secno">10.1.2. </span><span class="content">Active Network Attackers</span><a class="self-link" href="#active-network-attackers"></a></h4>
    <p>Active attackers, such as compromised routers, will be able to manipulate data
 exchanged between agents.  They can inject traffic into existing QUIC
 connections and attempt to initiate new QUIC connections.  These abilities can
@@ -2862,7 +2920,7 @@ expose local network devices (such as Open Screen Protocol agents) to the
 Internet.  This vector of attack has been used by malicious parties to take
 control of printers and smart TVs by connecting to local network services that
 would normally be inaccessible from the Internet.</p>
-   <h4 class="heading settled" data-level="9.1.3" id="denial-of-service"><span class="secno">9.1.3. </span><span class="content">Denial of Service</span><a class="self-link" href="#denial-of-service"></a></h4>
+   <h4 class="heading settled" data-level="10.1.3" id="denial-of-service"><span class="secno">10.1.3. </span><span class="content">Denial of Service</span><a class="self-link" href="#denial-of-service"></a></h4>
    <p>Parties with connected to the LAN may attempt to deny access to Open Screen
 Protocol agents.  For example, an attacker my attempt to open
 a large number of QUIC connections to an agent in an attempt to block
@@ -2870,7 +2928,7 @@ legitimate connections or exhaust the agent’s system resources.  They may
 also multicast spurious DNS-SD records in an attempt to exhaust the cache
 capacity for mDNS listeners, or to get listeners to open a large number of bogus
 QUIC connections.</p>
-   <h4 class="heading settled" data-level="9.1.4" id="same-origin-policy-violations"><span class="secno">9.1.4. </span><span class="content">Same-Origin Policy Violations</span><a class="self-link" href="#same-origin-policy-violations"></a></h4>
+   <h4 class="heading settled" data-level="10.1.4" id="same-origin-policy-violations"><span class="secno">10.1.4. </span><span class="content">Same-Origin Policy Violations</span><a class="self-link" href="#same-origin-policy-violations"></a></h4>
    <p>The Presentation API allows cross-origin communication between controlling pages
 and presentations with the consent of each origin (through their use of the
 API).  This is similar to cross-origin communication via <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage" id="ref-for-dom-window-postmessage">postMessage()</a></code> with a <code>targetOrigin</code> of <code>*</code>.  However, the Presentation API does not convey source
@@ -2878,8 +2936,8 @@ origin information with each message.  Therefore, the Open Screen Protocol does
 not convey origin information between its agents.</p>
    <p>The <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-presentation-id" id="ref-for-dfn-presentation-id③">presentation ID</a> carries some protection against unrestricted
 cross-origin access; but, rigorous authentication of the parties connected by a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/presentation-api/#presentationconnection" id="ref-for-presentationconnection②">PresentationConnection</a></code> must be done at the application level.</p>
-   <h3 class="heading settled" data-level="9.2" id="security-privacy-questions"><span class="secno">9.2. </span><span class="content">Open Screen Protocol Security and Privacy Considerations</span><a class="self-link" href="#security-privacy-questions"></a></h3>
-   <h4 class="heading settled" data-level="9.2.1" id="personally-identifiable-information"><span class="secno">9.2.1. </span><span class="content">Personally Identifiable Information &amp; High-Value Data</span><a class="self-link" href="#personally-identifiable-information"></a></h4>
+   <h3 class="heading settled" data-level="10.2" id="security-privacy-questions"><span class="secno">10.2. </span><span class="content">Open Screen Protocol Security and Privacy Considerations</span><a class="self-link" href="#security-privacy-questions"></a></h3>
+   <h4 class="heading settled" data-level="10.2.1" id="personally-identifiable-information"><span class="secno">10.2.1. </span><span class="content">Personally Identifiable Information &amp; High-Value Data</span><a class="self-link" href="#personally-identifiable-information"></a></h4>
    <p>The following data exchanged by the protocol can be personally identifiable
 and/or high value data:</p>
    <ol>
@@ -2911,20 +2969,20 @@ considered public and untrusted data:</p>
      <p>Data advertised through mDNS, including the display name prefix, the
 certificate fingerprint, and the metadata version.</p>
    </ol>
-   <h4 class="heading settled" data-level="9.2.2" id="cross-origin-state"><span class="secno">9.2.2. </span><span class="content">Cross Origin State Considerations</span><a class="self-link" href="#cross-origin-state"></a></h4>
+   <h4 class="heading settled" data-level="10.2.2" id="cross-origin-state"><span class="secno">10.2.2. </span><span class="content">Cross Origin State Considerations</span><a class="self-link" href="#cross-origin-state"></a></h4>
    <p>Access to origin state across browsing sessions is possible through the
 Presentation API by reconnecting to a presentation that was started by a
 previous session. This scenario is addressed in <a href="https://www.w3.org/TR/presentation-api/#cross-origin-access">Presentation API §cross-origin-access</a>.</p>
    <p>Presentation display availability and remote playback device availability are
 states that are available cross-origin depending on the user’s network
 context.  Exposure of this data to the Web is also discussed in <a href="https://www.w3.org/TR/presentation-api/#personally-identifiable-information">Presentation API §personally-identifiable-information</a> and <a href="https://www.w3.org/TR/remote-playback/#personally-identifiable-information">Remote Playback API §personally-identifiable-information</a>.</p>
-   <h4 class="heading settled" data-level="9.2.3" id="origin-access-devices"><span class="secno">9.2.3. </span><span class="content">Origin Access to Other Devices</span><a class="self-link" href="#origin-access-devices"></a></h4>
+   <h4 class="heading settled" data-level="10.2.3" id="origin-access-devices"><span class="secno">10.2.3. </span><span class="content">Origin Access to Other Devices</span><a class="self-link" href="#origin-access-devices"></a></h4>
    <p>By design, the Open Screen Protocol allows access to presentation displays and
 remote playback devices from the Web.  By implementing the protocol, these
 devices are knowingly making themselves available to the Web and should be
 designed accordingly.</p>
    <p>Below, we discuss mitigation steps to prevent malicious use of these devices.</p>
-   <h4 class="heading settled" data-level="9.2.4" id="incognito-mode"><span class="secno">9.2.4. </span><span class="content">Incognito Mode</span><a class="self-link" href="#incognito-mode"></a></h4>
+   <h4 class="heading settled" data-level="10.2.4" id="incognito-mode"><span class="secno">10.2.4. </span><span class="content">Incognito Mode</span><a class="self-link" href="#incognito-mode"></a></h4>
    <p>The Open Screen Protocol does not distinguish between the user agent’s normal
 browsing and incognito modes, and agents that follow the specification
 behave identically regardless of which mode is in use.</p>
@@ -2932,16 +2990,16 @@ behave identically regardless of which mode is in use.</p>
 connections for normal and incognito profiles from the same user agent instance.
 This prevents Open Screen agents from correlating activity among profiles
 belonging to the same user (both normal and incognito).</p>
-   <h4 class="heading settled" data-level="9.2.5" id="persistent-state"><span class="secno">9.2.5. </span><span class="content">Persistent State</span><a class="self-link" href="#persistent-state"></a></h4>
+   <h4 class="heading settled" data-level="10.2.5" id="persistent-state"><span class="secno">10.2.5. </span><span class="content">Persistent State</span><a class="self-link" href="#persistent-state"></a></h4>
    <p>An agent is likely to persist the identity of agents that have successfully
-completed <a href="#authentication">§6 Authentication</a>.  This may include the public key fingerprints,
+completed <a href="#authentication">§ 6 Authentication</a>.  This may include the public key fingerprints,
 metadata versions, and metadata for those parties.</p>
    <p>However, this data is not normally exposed to the Web, only through the native
 UI of the user agent during the display selection or display authentication
 process.  It can be an implementation choice whether the user agent clears or
 retains this data when the user clears browsing data.</p>
    <p class="issue" id="issue-8bf4aa9f"><a class="self-link" href="#issue-8bf4aa9f"></a> Fate of metadata / authentication history when clearing browsing data. <a href="https://github.com/webscreens/openscreenprotocol/issues/132">&lt;https://github.com/webscreens/openscreenprotocol/issues/132></a></p>
-   <h4 class="heading settled" data-level="9.2.6" id="other-considerations"><span class="secno">9.2.6. </span><span class="content">Other Considerations</span><a class="self-link" href="#other-considerations"></a></h4>
+   <h4 class="heading settled" data-level="10.2.6" id="other-considerations"><span class="secno">10.2.6. </span><span class="content">Other Considerations</span><a class="self-link" href="#other-considerations"></a></h4>
    <p>The Open Screen Protocol does not grant to the Web additional access to the
 following:</p>
    <ul>
@@ -2958,7 +3016,7 @@ following:</p>
     <li data-md>
      <p>Security characteristics of the user agent</p>
    </ul>
-   <h3 class="heading settled" data-level="9.3" id="presentation-api-considerations"><span class="secno">9.3. </span><span class="content">Presentation API Considerations</span><a class="self-link" href="#presentation-api-considerations"></a></h3>
+   <h3 class="heading settled" data-level="10.3" id="presentation-api-considerations"><span class="secno">10.3. </span><span class="content">Presentation API Considerations</span><a class="self-link" href="#presentation-api-considerations"></a></h3>
    <p><a href="https://www.w3.org/TR/presentation-api/#security-and-privacy-considerations">Presentation API §security-and-privacy-considerations</a> place these
 requirements on the Open Screen Protocol:</p>
    <ol>
@@ -2985,15 +3043,15 @@ connections.</p>
  the number of active connections.</p>
    </ol>
    <p class="issue" id="issue-edc1d8c1"><a class="self-link" href="#issue-edc1d8c1"></a> Notify endpoints when new connection is created. <a href="https://github.com/webscreens/openscreenprotocol/issues/143">&lt;https://github.com/webscreens/openscreenprotocol/issues/143></a></p>
-   <h3 class="heading settled" data-level="9.4" id="remote-playback-considerations"><span class="secno">9.4. </span><span class="content">Remote Playback API Considerations</span><a class="self-link" href="#remote-playback-considerations"></a></h3>
+   <h3 class="heading settled" data-level="10.4" id="remote-playback-considerations"><span class="secno">10.4. </span><span class="content">Remote Playback API Considerations</span><a class="self-link" href="#remote-playback-considerations"></a></h3>
    <p>The <a href="https://www.w3.org/TR/remote-playback/#security-and-privacy-considerations">Remote Playback API §security-and-privacy-considerations</a> also state that
 messaging between local and remote playback devices should also be authenticated
 and confidential.</p>
    <p>This consideration is handled by requiring mutual authentication and a
 TLS-secured QUIC connection before any remote playback related messages are
 exchanged.</p>
-   <h3 class="heading settled" data-level="9.5" id="security-mitigations"><span class="secno">9.5. </span><span class="content">Mitigation Strategies</span><a class="self-link" href="#security-mitigations"></a></h3>
-   <h4 class="heading settled" data-level="9.5.1" id="local-passive-mitigations"><span class="secno">9.5.1. </span><span class="content">Local passive network attackers</span><a class="self-link" href="#local-passive-mitigations"></a></h4>
+   <h3 class="heading settled" data-level="10.5" id="security-mitigations"><span class="secno">10.5. </span><span class="content">Mitigation Strategies</span><a class="self-link" href="#security-mitigations"></a></h3>
+   <h4 class="heading settled" data-level="10.5.1" id="local-passive-mitigations"><span class="secno">10.5.1. </span><span class="content">Local passive network attackers</span><a class="self-link" href="#local-passive-mitigations"></a></h4>
    <p>Local passive attackers may attempt to harvest data about user activities and
 device capabilities using the Open Screen Protocol.  The main strategy to address
 this is data minimization, by only exposing opaque public key fingerprints
@@ -3001,9 +3059,9 @@ before user-mediated authentication takes place.</p>
    <p>Passive attackers may also attempt timing attacks to learn the
 cryptographic parameters of the TLS 1.3 QUIC connection.</p>
    <p class="issue" id="issue-84520e29"><a class="self-link" href="#issue-84520e29"></a> Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a></p>
-   <h4 class="heading settled" data-level="9.5.2" id="local-active-mitigations"><span class="secno">9.5.2. </span><span class="content">Local active network attackers</span><a class="self-link" href="#local-active-mitigations"></a></h4>
+   <h4 class="heading settled" data-level="10.5.2" id="local-active-mitigations"><span class="secno">10.5.2. </span><span class="content">Local active network attackers</span><a class="self-link" href="#local-active-mitigations"></a></h4>
    <p>Local active attackers may attempt to impersonate a presentation display the
-user would normally trust.  The <a href="#authentication">§6 Authentication</a> step of the Open Screen
+user would normally trust.  The <a href="#authentication">§ 6 Authentication</a> step of the Open Screen
 Protocol prevents a man-in-the-middle from impersonating an agent, without
 knowledge of a shared secret.  However, it is possible for an attacker to
 impersonate an existing, trusted display or a newly discovered display that is
@@ -3048,19 +3106,19 @@ display - to prevent the user from blindly clicking through this step.</p>
 connection by injecting or modifying traffic.  These attacks should be mitigated
 by a correct implementation of TLS 1.3.</p>
    <p class="issue" id="issue-84520e29①"><a class="self-link" href="#issue-84520e29①"></a> Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a></p>
-   <h4 class="heading settled" data-level="9.5.3" id="remote-active-mitigations"><span class="secno">9.5.3. </span><span class="content">Remote active network attackers</span><a class="self-link" href="#remote-active-mitigations"></a></h4>
+   <h4 class="heading settled" data-level="10.5.3" id="remote-active-mitigations"><span class="secno">10.5.3. </span><span class="content">Remote active network attackers</span><a class="self-link" href="#remote-active-mitigations"></a></h4>
    <p>Unfortunately, we cannot rely on network devices to fully protect Open Screen
 Protocol agents, because a misconfigured firewall or NAT could expose a
 LAN-connected agent to the broader Internet.  Open Screen Protocol agents
 should be secure against attack from any Internet host.</p>
    <p class="issue" id="issue-7e863472"><a class="self-link" href="#issue-7e863472"></a> Mitigations for remote network attackers. <a href="https://github.com/webscreens/openscreenprotocol/issues/131">&lt;https://github.com/webscreens/openscreenprotocol/issues/131></a></p>
-   <h4 class="heading settled" data-level="9.5.4" id="denial-of-service-mitigations"><span class="secno">9.5.4. </span><span class="content">Denial of service</span><a class="self-link" href="#denial-of-service-mitigations"></a></h4>
+   <h4 class="heading settled" data-level="10.5.4" id="denial-of-service-mitigations"><span class="secno">10.5.4. </span><span class="content">Denial of service</span><a class="self-link" href="#denial-of-service-mitigations"></a></h4>
    <p>It will be difficult to completely prevent denial service of attacks that
 originate on the user’s local area network.  Open Screen Protocol agents can
 refuse new connections, close connections that receive too many messages, or
 limit the number of mDNS records cached from a specific responder in an attempt
 to allow existing activities to continue in spite of such an attack.</p>
-   <h4 class="heading settled" data-level="9.5.5" id="malicious-input-mitigations"><span class="secno">9.5.5. </span><span class="content">Malicious input</span><a class="self-link" href="#malicious-input-mitigations"></a></h4>
+   <h4 class="heading settled" data-level="10.5.5" id="malicious-input-mitigations"><span class="secno">10.5.5. </span><span class="content">Malicious input</span><a class="self-link" href="#malicious-input-mitigations"></a></h4>
    <p>Open Screen Protocol agents should be robust against malicious input that
 attempts to compromise the target device by exploiting parsing vulnerabilities.</p>
    <p>CBOR is intended to be less vulnerable to such attacks relative to alternatives
@@ -3780,15 +3838,15 @@ because smaller type keys encode on the wire smaller.</p>
   <aside class="dfn-panel" data-for="term-for-dom-window-postmessage">
    <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-window-postmessage">9.1.4. Same-Origin Policy Violations</a>
+    <li><a href="#ref-for-dom-window-postmessage">10.1.4. Same-Origin Policy Violations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-presentationconnection">
    <a href="https://w3c.github.io/presentation-api/#presentationconnection">https://w3c.github.io/presentation-api/#presentationconnection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-presentationconnection">2.1. Presentation API Requirements</a> <a href="#ref-for-presentationconnection①">(2)</a>
-    <li><a href="#ref-for-presentationconnection②">9.1.4. Same-Origin Policy Violations</a>
-    <li><a href="#ref-for-presentationconnection③">9.3. Presentation API Considerations</a>
+    <li><a href="#ref-for-presentationconnection②">10.1.4. Same-Origin Policy Violations</a>
+    <li><a href="#ref-for-presentationconnection③">10.3. Presentation API Considerations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-available-presentation-display">
@@ -3828,7 +3886,7 @@ because smaller type keys encode on the wire smaller.</p>
    <a href="https://w3c.github.io/presentation-api/#dfn-presentation-id">https://w3c.github.io/presentation-api/#dfn-presentation-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-presentation-id">2.1. Presentation API Requirements</a> <a href="#ref-for-dfn-presentation-id①">(2)</a> <a href="#ref-for-dfn-presentation-id②">(3)</a>
-    <li><a href="#ref-for-dfn-presentation-id③">9.1.4. Same-Origin Policy Violations</a>
+    <li><a href="#ref-for-dfn-presentation-id③">10.1.4. Same-Origin Policy Violations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-presentation-request-url">
@@ -3957,7 +4015,7 @@ because smaller type keys encode on the wire smaller.</p>
    <dt id="biblio-rfc7049">[RFC7049]
    <dd>C. Bormann; P. Hoffman. <a href="https://tools.ietf.org/html/rfc7049">Concise Binary Object Representation (CBOR)</a>. October 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7049">https://tools.ietf.org/html/rfc7049</a>
    <dt id="biblio-security-privacy-questionnaire">[SECURITY-PRIVACY-QUESTIONNAIRE]
-   <dd>Mike West. <a href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire: Security and Privacy</a>. 10 December 2015. NOTE. URL: <a href="https://www.w3.org/TR/security-privacy-questionnaire/">https://www.w3.org/TR/security-privacy-questionnaire/</a>
+   <dd>Lukasz Olejnik; Jason Novak. <a href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire: Security and Privacy</a>. 23 May 2019. NOTE. URL: <a href="https://www.w3.org/TR/security-privacy-questionnaire/">https://www.w3.org/TR/security-privacy-questionnaire/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
@@ -3971,7 +4029,6 @@ because smaller type keys encode on the wire smaller.</p>
    <div class="issue"> Clarify scoping/uniqueness of request IDs. <a href="https://github.com/webscreens/openscreenprotocol/issues/139">&lt;https://github.com/webscreens/openscreenprotocol/issues/139></a><a href="#issue-7a02cf11"> ↵ </a></div>
    <div class="issue"> Add a capability that indicates support for the presentation protocol. <a href="https://github.com/webscreens/openscreenprotocol/issues/123">&lt;https://github.com/webscreens/openscreenprotocol/issues/123></a><a href="#issue-4f0d9dbd"> ↵ </a></div>
    <div class="issue"> Refinements to Presentation API protocol. <a href="https://github.com/webscreens/openscreenprotocol/issues/160">&lt;https://github.com/webscreens/openscreenprotocol/issues/160></a><a href="#issue-905f29c0"> ↵ </a></div>
-   <div class="issue"> Watch ID Uniqueness. <a href="https://github.com/webscreens/openscreenprotocol/issues/145">&lt;https://github.com/webscreens/openscreenprotocol/issues/145></a><a href="#issue-23b856c4"> ↵ </a></div>
    <div class="issue"> Is a Presentation close/terminate from a controller a request/response or event? <a href="https://github.com/webscreens/openscreenprotocol/issues/124">&lt;https://github.com/webscreens/openscreenprotocol/issues/124></a><a href="#issue-b4b59633"> ↵ </a></div>
    <div class="issue"> Remove presentation-connection-close-response message. <a href="https://github.com/webscreens/openscreenprotocol/issues/138">&lt;https://github.com/webscreens/openscreenprotocol/issues/138></a><a href="#issue-1a6da4e3"> ↵ </a></div>
    <div class="issue"> Once the Presentation API has text about reconnecting via an

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -26,7 +26,8 @@ agent-capability = &(
 agent-info = {
   0: text ; display-name
   1: text ; model-name
-  2: [* agent-capabilitiy] ; capabilities
+  2: [* agent-capability] ; capabilities
+  3: text ; state-token
 }
 
 ; type key 12
@@ -94,12 +95,14 @@ auth-status-result = &(
   proof-invalid: 5
 )
 
+watch-id = uint
+
 ; type key 14
 presentation-url-availability-request = {
   request
   1: [1* text] ; urls
   2: microseconds ; watch-duration
-  3: uint ; watch-id
+  3: watch-id ; watch-id
 }
 
 ; type key 15
@@ -110,7 +113,7 @@ presentation-url-availability-response = {
 
 ; type key 103
 presentation-url-availability-event = {
-  1: uint ; watch-id
+  1: watch-id ; watch-id
   2: [1* url-availability] ; url-availabilities
 }
 
@@ -234,7 +237,7 @@ remote-playback-availability-request = {
   request
   1: [* text] ; urls
   2: microseconds ; watch-duration
-  3: int ; watch-id
+  3: watch-id ; watch-id
 }
 
 ; type key 18
@@ -245,7 +248,7 @@ remote-playback-availability-response = {
 
 ; type key 114
 remote-playback-availability-event = {
-  1: int ; watch-id
+  1: watch-id ; watch-id
   2: [* url-availability] ; url-availabilities
 }
 


### PR DESCRIPTION
This PR addresses issue #139 (Clarify scoping/uniqueness of request IDs) and issue #145 (Watch ID uniqueness).  In the Berlin F2F, we resolved to use a single per-agent counter and a state token to notify others when the counter is reset [1].

This PR also makes the following clarifications:

- agent-info is part of agent-info-response
- watch-id is always a uint
- Consolidates notes about ID lifetime/uniqueness and independence from connection lifetime into a single section.

[1] https://www.w3.org/2019/05/24-webscreens-minutes.html#x05


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/pull/181.html" title="Last updated on Aug 8, 2019, 7:20 PM UTC (6458540)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/181/db6056d...6458540.html" title="Last updated on Aug 8, 2019, 7:20 PM UTC (6458540)">Diff</a>