### PR TITLE
Adds presentation-change-event.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -840,7 +840,7 @@ When [[PRESENTATION-API#closing-a-presentationconnection|section 6.5.5]] says
 "Start to signal to the destination browsing context the intention to close the
 corresponding PresentationConnection", the [=user agent=] may send a
 `presentation-connection-close-event` message to the user agent with the
-destination browsing context.
+destination browsing context and a `presentation-change-event` when required.
 
 When
 [[PRESENTATION-API#terminating-a-presentation-in-a-controlling-browsing-context|section

--- a/index.bs
+++ b/index.bs
@@ -747,7 +747,7 @@ following values:
     across connections, thus making message demuxing/routing easier).
 
 : connection-count
-:: The new total number of connections open to the presentation that received
+:: The new number of open connections to the presentation that received
     the incoming connection request.
 
 If the `presentation-connection-open-response` message indicates success, the
@@ -756,11 +756,10 @@ that have an active presentation connection to that presentation with the
 values:
 
 : presentation-id
-:: The ID of the presentation that just received a new connection.
+:: The ID of the presentation that just received a new presentation connection.
 
 : connection-count
-:: The new total number of connections open to the presentation that received
-    the incoming connection request.
+:: The new total number of open connections to that presentation.
 
 A controller may close a connection without terminating the presentation by
 sending a `presentation-connection-close-event` message to the receiver with the
@@ -781,6 +780,19 @@ controller with the following values:
 
 : reason
 :: Set to `close-method-called` or `connection-object-discarded`.
+
+: connection-count
+:: The number of open presentation connections that remain.
+
+If a receiver closes a presentation connection (for any reason), it should send
+a `presentation-change-event` to all other controllers with an open connection
+to that presentation with the values:
+
+: presentation-id
+:: The ID of the presentation that just closed a connection.
+
+: connection-count
+:: The number of open presentation connections that remain.
 
 Note: When an agent closes a presentation connection, it is always successful,
 so request and response messages are not needed.  A request to terminate a

--- a/index.bs
+++ b/index.bs
@@ -746,6 +746,22 @@ following values:
     the message receiver chooses the connection-id, it may keep the ID unique
     across connections, thus making message demuxing/routing easier).
 
+: connection-count
+:: The new total number of connections open to the presentation that received
+    the incoming connection request.
+
+If the `presentation-connection-open-response` message indicates success, the
+receiver should also send a `presentation-change-event` to all other endpoints
+that have an active presentation connection to that presentation with the
+values:
+
+: presentation-id
+:: The ID of the presentation that just received a new connection.
+
+: connection-count
+:: The new total number of connections open to the presentation that received
+    the incoming connection request.
+
 A controller may close a connection without terminating the presentation by
 sending a `presentation-connection-close-event` message to the receiver with the
 following values:
@@ -829,8 +845,9 @@ presentation-connection-open-request.
 
 When [[PRESENTATION-API#monitoring-incoming-presentation-connections|section
 6.7.1]] says "Establish the connection between the controlling and receiving
-browsing contexts using an implementation specific mechanism.", the [=receiving
-user agent=], must send a presentation-connection-open-response message.
+browsing contexts using an implementation specific mechanism," the [=receiving
+user agent=] must send a presentation-connection-open-response message and
+`presentation-change-event` messages when required.
 
 
 Remote Playback Protocol {#remote-playback-protocol}

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="6fc056274a9705b4e1d5bad14e25510d3b424c58" name="document-revision">
+  <meta content="e95b284b02bd76f633896a31cf4a499d79f04551" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -2268,7 +2268,7 @@ message.</p>
    <p>When <a href="https://www.w3.org/TR/presentation-api/#closing-a-presentationconnection">section 6.5.5</a> says
 "Start to signal to the destination browsing context the intention to close the
 corresponding PresentationConnection", the <a data-link-type="dfn" href="https://w3c.github.io/reporting/#report-user-agent" id="ref-for-report-user-agent">user agent</a> may send a <code>presentation-connection-close-event</code> message to the user agent with the
-destination browsing context.</p>
+destination browsing context and a <code>presentation-change-event</code> when required.</p>
    <p>When <a href="https://www.w3.org/TR/presentation-api/#terminating-a-presentation-in-a-controlling-browsing-context">section
 6.5.6</a> says "Send a termination request for the presentation to its receiving
 user agent using an implementation specific mechanism", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent" id="ref-for-dfn-controlling-user-agent⑦">controlling user
@@ -3434,6 +3434,7 @@ the wire smaller.</p>
   <span class="nx">response</span>
 <span class="nx">  1</span><span class="p">:</span> <span class="o">&amp;</span><span class="nx">result </span><span class="c1">; result</span>
   <span class="mi">2</span><span class="p">:</span> <span class="kt">uint</span><span class="c1">; connection-id</span>
+  <span class="mi">3</span><span class="p">:</span> <span class="kt">uint</span><span class="c1">; connection-count</span>
 <span class="p">}</span></p>
 
 <p><span class="c1">; type key 113</span>
@@ -3445,6 +3446,13 @@ the wire smaller.</p>
     <span class="nx">unrecoverable-error-while-sending-or-receiving-message</span><span class="p">:</span> <span class="mi">100</span>
   <span class="p">)</span> <span class="c1">; reason</span>
   <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; error-message</span>
+  <span class="mi">4</span><span class="p">:</span> <span class="kt">uint</span><span class="c1">; connection-count</span>
+<span class="p">}</span></p>
+
+<p><span class="c1">; type key 121</span>
+<span class="nx">presentation-change-event </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; presentation-id</span>
+  <span class="mi">2</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; connection-count</span>
 <span class="p">}</span></p>
 
 <p><span class="c1">; type key 16</span>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="7dff2d7c8fff7ebcc94aecdb94f08b132d231203" name="document-revision">
+  <meta content="cb943811fc0b053b8fd07759438e94585c5d6f6b" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -2183,6 +2183,23 @@ following values:</p>
 to each other.  It is chosen by the receiver for ease of implementation (if
 the message receiver chooses the connection-id, it may keep the ID unique
 across connections, thus making message demuxing/routing easier).</p>
+    <dt data-md>connection-count
+    <dd data-md>
+     <p>The new total number of connections open to the presentation that received
+the incoming connection request.</p>
+   </dl>
+   <p>If the <code>presentation-connection-open-response</code> message indicates success, the
+receiver should also send a <code>presentation-change-event</code> to all other endpoints
+that have an active presentation connection to that presentation with the
+values:</p>
+   <dl>
+    <dt data-md>presentation-id
+    <dd data-md>
+     <p>The ID of the presentation that just received a new connection.</p>
+    <dt data-md>connection-count
+    <dd data-md>
+     <p>The new total number of connections open to the presentation that received
+the incoming connection request.</p>
    </dl>
    <p>A controller may close a connection without terminating the presentation by
 sending a <code>presentation-connection-close-event</code> message to the receiver with the
@@ -2250,8 +2267,8 @@ mechanism", the <a data-link-type="dfn" href="https://w3c.github.io/presentation
 presentation-connection-open-request.</p>
    <p>When <a href="https://www.w3.org/TR/presentation-api/#monitoring-incoming-presentation-connections">section
 6.7.1</a> says "Establish the connection between the controlling and receiving
-browsing contexts using an implementation specific mechanism.", the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent" id="ref-for-dfn-receiving-user-agent②">receiving
-user agent</a>, must send a presentation-connection-open-response message.</p>
+browsing contexts using an implementation specific mechanism," the <a data-link-type="dfn" href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent" id="ref-for-dfn-receiving-user-agent②">receiving
+user agent</a> must send a presentation-connection-open-response message and <code>presentation-change-event</code> messages when required.</p>
    <h2 class="heading settled" data-level="8" id="remote-playback-protocol"><span class="secno">8. </span><span class="content">Remote Playback Protocol</span><a class="self-link" href="#remote-playback-protocol"></a></h2>
    <p>This section defines the use of the Open Screen Protocol for starting, terminating,
 and controlling remote playback of media as defined by the <a data-link-type="biblio" href="#biblio-remote-playback">Remote Playback API</a>. <a href="#remote-playback-api">§ 8.2 Remote Playback API</a> defines how

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="cb943811fc0b053b8fd07759438e94585c5d6f6b" name="document-revision">
+  <meta content="6fc056274a9705b4e1d5bad14e25510d3b424c58" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-19">19 August 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-20">20 August 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2185,7 +2185,7 @@ the message receiver chooses the connection-id, it may keep the ID unique
 across connections, thus making message demuxing/routing easier).</p>
     <dt data-md>connection-count
     <dd data-md>
-     <p>The new total number of connections open to the presentation that received
+     <p>The new number of open connections to the presentation that received
 the incoming connection request.</p>
    </dl>
    <p>If the <code>presentation-connection-open-response</code> message indicates success, the
@@ -2195,11 +2195,10 @@ values:</p>
    <dl>
     <dt data-md>presentation-id
     <dd data-md>
-     <p>The ID of the presentation that just received a new connection.</p>
+     <p>The ID of the presentation that just received a new presentation connection.</p>
     <dt data-md>connection-count
     <dd data-md>
-     <p>The new total number of connections open to the presentation that received
-the incoming connection request.</p>
+     <p>The new total number of open connections to that presentation.</p>
    </dl>
    <p>A controller may close a connection without terminating the presentation by
 sending a <code>presentation-connection-close-event</code> message to the receiver with the
@@ -2222,6 +2221,20 @@ controller with the following values:</p>
     <dt data-md>reason
     <dd data-md>
      <p>Set to <code>close-method-called</code> or <code>connection-object-discarded</code>.</p>
+    <dt data-md>connection-count
+    <dd data-md>
+     <p>The number of open presentation connections that remain.</p>
+   </dl>
+   <p>If a receiver closes a presentation connection (for any reason), it should send
+a <code>presentation-change-event</code> to all other controllers with an open connection
+to that presentation with the values:</p>
+   <dl>
+    <dt data-md>presentation-id
+    <dd data-md>
+     <p>The ID of the presentation that just closed a connection.</p>
+    <dt data-md>connection-count
+    <dd data-md>
+     <p>The number of open presentation connections that remain.</p>
    </dl>
    <p class="note" role="note"><span>Note:</span> When an agent closes a presentation connection, it is always successful,
 so request and response messages are not needed.  A request to terminate a

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -208,6 +208,7 @@ presentation-connection-close-event = {
     unrecoverable-error-while-sending-or-receiving-message: 100
   ) ; reason
   ? 3: text ; error-message
+  4: uint; connection-count
 }
 
 ; type key 121

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -196,6 +196,7 @@ presentation-connection-open-response = {
   response
   1: &result ; result
   2: uint; connection-id
+  3: uint; connection-count
 }
 
 ; type key 113
@@ -207,6 +208,12 @@ presentation-connection-close-event = {
     unrecoverable-error-while-sending-or-receiving-message: 100
   ) ; reason
   ? 3: text ; error-message
+}
+
+; type key 121
+presentation-change-event = {
+  1: text ; presentation-id
+  2: uint ; connection-count
 }
 
 ; type key 16

--- a/messages_appendix.html
+++ b/messages_appendix.html
@@ -196,6 +196,7 @@
   <span class="nx">response</span>
 <span class="nx">  1</span><span class="p">:</span> <span class="o">&amp;</span><span class="nx">result </span><span class="c1">; result</span>
   <span class="mi">2</span><span class="p">:</span> <span class="kt">uint</span><span class="c1">; connection-id</span>
+  <span class="mi">3</span><span class="p">:</span> <span class="kt">uint</span><span class="c1">; connection-count</span>
 <span class="p">}</span>
 
 <span class="c1">; type key 113</span>
@@ -207,6 +208,13 @@
     <span class="nx">unrecoverable-error-while-sending-or-receiving-message</span><span class="p">:</span> <span class="mi">100</span>
   <span class="p">)</span> <span class="c1">; reason</span>
   <span class="p">?</span> <span class="mi">3</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; error-message</span>
+  <span class="mi">4</span><span class="p">:</span> <span class="kt">uint</span><span class="c1">; connection-count</span>
+<span class="p">}</span>
+
+<span class="c1">; type key 121</span>
+<span class="nx">presentation-change-event </span><span class="p">=</span> <span class="p">{</span>
+  <span class="mi">1</span><span class="p">:</span> <span class="nx">text </span><span class="c1">; presentation-id</span>
+  <span class="mi">2</span><span class="p">:</span> <span class="kt">uint</span> <span class="c1">; connection-count</span>
 <span class="p">}</span>
 
 <span class="c1">; type key 16</span>


### PR DESCRIPTION
This addresses Issue #143: Notify endpoints when new connection is created.

It adds a presentation-change-event message that is sent to all other connected presentation controllers when a presentation receiver accepts an incoming connection request.

Discussed here at the F2F: https://www.w3.org/2019/05/23-webscreens-minutes.html#x22


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/pull/187.html" title="Last updated on Aug 21, 2019, 4:09 PM UTC (3ab315d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/187/2164e92...3ab315d.html" title="Last updated on Aug 21, 2019, 4:09 PM UTC (3ab315d)">Diff</a>