### PR TITLE
Replace pw with at.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -346,12 +346,12 @@ Issue: Include cross references to the specs for these hash functions.
 
 The advertising agent should add an additional field to the TXT record:
 
-: pw
+: at
 :: An alphanumeric, unguessable token consisting of characters from the set
     `[A-Za-z0-9+/]`.
 
-Note: `pw` prevents off-LAN parties from attempting authentication; see
-[[#remote-active-mitigations]].  `pw` should have at least 32 bits of true
+Note: `at` prevents off-LAN parties from attempting authentication; see
+[[#remote-active-mitigations]].  `at` should have at least 32 bits of true
 entropy to make brute force attacks impractical.
 
 Issue: Add examples of sample mDNS records.
@@ -532,10 +532,10 @@ support the numeric PSK input method.
 
 Any authentication method may require an `auth-initation-token` before showing a
 PSK to the user or requesting PSK input from the user.  If an [=advertising
-agent=] has the `pw` field in its mDNS TXT record, it must be used as the
+agent=] has the `at` field in its mDNS TXT record, it must be used as the
 `auth-initation-token` in the the first authentication message sent to or from
 that agent.  Agents should discard any authentication message whose
-`auth-initation-token` is set and does not match the `pw` provided by the
+`auth-initation-token` is set and does not match the `at` provided by the
 advertising agent.
 
 Authentication with SPAKE2 {#authentication-with-spake2}
@@ -1931,7 +1931,7 @@ Protocol agents, because a misconfigured firewall or NAT could expose a
 LAN-connected agent to the broader Internet.  Open Screen Protocol agents
 should be secure against attack from any Internet host.
 
-Advertising agents should set the `pw` field in their mDNS TXT record to protect
+Advertising agents should set the `at` field in their mDNS TXT record to protect
 themselves from off-LAN attempts to initiate [[#authentication]], which result
 in user annoyance (display or input of PSK) and potential brute force attacks
 against the PSK.

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="cb943811fc0b053b8fd07759438e94585c5d6f6b" name="document-revision">
+  <meta content="9ffc015d301e85bf25b6c16879c86ff659a4d6ed" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-19">19 August 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-20">20 August 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1831,11 +1831,11 @@ advertising agent to discover updated metadata.</p>
    </dl>
    <p>The advertising agent should add an additional field to the TXT record:</p>
    <dl>
-    <dt data-md>pw
+    <dt data-md>at
     <dd data-md>
      <p>An alphanumeric, unguessable token consisting of characters from the set <code>[A-Za-z0-9+/]</code>.</p>
    </dl>
-   <p class="note" role="note"><span>Note:</span> <code>pw</code> prevents off-LAN parties from attempting authentication; see <a href="#remote-active-mitigations">§ 12.5.3 Remote active network attackers</a>. <code>pw</code> should have at least 32 bits of true
+   <p class="note" role="note"><span>Note:</span> <code>at</code> prevents off-LAN parties from attempting authentication; see <a href="#remote-active-mitigations">§ 12.5.3 Remote active network attackers</a>. <code>at</code> should have at least 32 bits of true
 entropy to make brute force attacks impractical.</p>
    <p class="issue" id="issue-49bdd4e6"><a class="self-link" href="#issue-49bdd4e6"></a> Add examples of sample mDNS records.</p>
    <p>Future extensions to this QUIC-based protocol can use the same metadata
@@ -1988,8 +1988,8 @@ are numeric and scanning a QR-code.  Devices with non-zero PSK ease of input mus
 support the numeric PSK input method.</p>
    <p>Any authentication method may require an <code>auth-initation-token</code> before showing a
 PSK to the user or requesting PSK input from the user.  If an <a data-link-type="dfn" href="#advertising-agent" id="ref-for-advertising-agent">advertising
-agent</a> has the <code>pw</code> field in its mDNS TXT record, it must be used as the <code>auth-initation-token</code> in the the first authentication message sent to or from
-that agent.  Agents should discard any authentication message whose <code>auth-initation-token</code> is set and does not match the <code>pw</code> provided by the
+agent</a> has the <code>at</code> field in its mDNS TXT record, it must be used as the <code>auth-initation-token</code> in the the first authentication message sent to or from
+that agent.  Agents should discard any authentication message whose <code>auth-initation-token</code> is set and does not match the <code>at</code> provided by the
 advertising agent.</p>
    <h3 class="heading settled" data-level="6.1" id="authentication-with-spake2"><span class="secno">6.1. </span><span class="content">Authentication with SPAKE2</span><a class="self-link" href="#authentication-with-spake2"></a></h3>
    <p>For all messages and objects defined in this section, see Appendix A for
@@ -3175,7 +3175,7 @@ by a correct implementation of TLS 1.3.</p>
 Protocol agents, because a misconfigured firewall or NAT could expose a
 LAN-connected agent to the broader Internet.  Open Screen Protocol agents
 should be secure against attack from any Internet host.</p>
-   <p>Advertising agents should set the <code>pw</code> field in their mDNS TXT record to protect
+   <p>Advertising agents should set the <code>at</code> field in their mDNS TXT record to protect
 themselves from off-LAN attempts to initiate <a href="#authentication">§ 6 Authentication</a>, which result
 in user annoyance (display or input of PSK) and potential brute force attacks
 against the PSK.</p>


### PR DESCRIPTION
Followup to PR #182 (mDNS token).  This renames the mDNS token from `pw` to `at` as suggested by @pthatcherg for consistency with the CBOR field.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/pull/188.html" title="Last updated on Aug 20, 2019, 11:27 PM UTC (ef075d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/188/9ffc015...ef075d0.html" title="Last updated on Aug 20, 2019, 11:27 PM UTC (ef075d0)">Diff</a>