### PR TITLE
Make auth-initiation-token mandatory.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -344,8 +344,6 @@ Issue: Include cross references to the specs for these hash functions.
     value.  This signals to the listening agent that it should connect to the
     advertising agent to discover updated metadata.
 
-The advertising agent should add an additional field to the TXT record:
-
 : at
 :: An alphanumeric, unguessable token consisting of characters from the set
     `[A-Za-z0-9+/]`.
@@ -531,8 +529,8 @@ are numeric and scanning a QR-code.  Devices with non-zero PSK ease of input mus
 support the numeric PSK input method.
 
 Any authentication method may require an `auth-initation-token` before showing a
-PSK to the user or requesting PSK input from the user.  If an [=advertising
-agent=] has the `at` field in its mDNS TXT record, it must be used as the
+PSK to the user or requesting PSK input from the user.  For an [=advertising
+agent=], the `at` field in its mDNS TXT record must be used as the
 `auth-initation-token` in the the first authentication message sent to or from
 that agent.  Agents should discard any authentication message whose
 `auth-initation-token` is set and does not match the `at` provided by the
@@ -1931,7 +1929,7 @@ Protocol agents, because a misconfigured firewall or NAT could expose a
 LAN-connected agent to the broader Internet.  Open Screen Protocol agents
 should be secure against attack from any Internet host.
 
-Advertising agents should set the `at` field in their mDNS TXT record to protect
+Advertising agents must set the `at` field in their mDNS TXT record to protect
 themselves from off-LAN attempts to initiate [[#authentication]], which result
 in user annoyance (display or input of PSK) and potential brute force attacks
 against the PSK.

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="9ffc015d301e85bf25b6c16879c86ff659a4d6ed" name="document-revision">
+  <meta content="af6c432b053540091b197264cf9a02c1d6366ff5" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1828,9 +1828,6 @@ Agents must not support the following hash functions: "md2", "md5".</p>
 metadata has changed.   The advertising agent must update it to a greater
 value.  This signals to the listening agent that it should connect to the
 advertising agent to discover updated metadata.</p>
-   </dl>
-   <p>The advertising agent should add an additional field to the TXT record:</p>
-   <dl>
     <dt data-md>at
     <dd data-md>
      <p>An alphanumeric, unguessable token consisting of characters from the set <code>[A-Za-z0-9+/]</code>.</p>
@@ -1987,8 +1984,8 @@ that it’s easy for the user to input PSK on the device.  Supported PSK input m
 are numeric and scanning a QR-code.  Devices with non-zero PSK ease of input must
 support the numeric PSK input method.</p>
    <p>Any authentication method may require an <code>auth-initation-token</code> before showing a
-PSK to the user or requesting PSK input from the user.  If an <a data-link-type="dfn" href="#advertising-agent" id="ref-for-advertising-agent">advertising
-agent</a> has the <code>at</code> field in its mDNS TXT record, it must be used as the <code>auth-initation-token</code> in the the first authentication message sent to or from
+PSK to the user or requesting PSK input from the user.  For an <a data-link-type="dfn" href="#advertising-agent" id="ref-for-advertising-agent">advertising
+agent</a>, the <code>at</code> field in its mDNS TXT record must be used as the <code>auth-initation-token</code> in the the first authentication message sent to or from
 that agent.  Agents should discard any authentication message whose <code>auth-initation-token</code> is set and does not match the <code>at</code> provided by the
 advertising agent.</p>
    <h3 class="heading settled" data-level="6.1" id="authentication-with-spake2"><span class="secno">6.1. </span><span class="content">Authentication with SPAKE2</span><a class="self-link" href="#authentication-with-spake2"></a></h3>
@@ -3175,7 +3172,7 @@ by a correct implementation of TLS 1.3.</p>
 Protocol agents, because a misconfigured firewall or NAT could expose a
 LAN-connected agent to the broader Internet.  Open Screen Protocol agents
 should be secure against attack from any Internet host.</p>
-   <p>Advertising agents should set the <code>at</code> field in their mDNS TXT record to protect
+   <p>Advertising agents must set the <code>at</code> field in their mDNS TXT record to protect
 themselves from off-LAN attempts to initiate <a href="#authentication">§ 6 Authentication</a>, which result
 in user annoyance (display or input of PSK) and potential brute force attacks
 against the PSK.</p>


### PR DESCRIPTION
Resolves Issue #185: Consider making auth-initiation-token mandatory.

I don't see any disadvantage, at least for the local network discovery use case.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/pull/189.html" title="Last updated on Aug 20, 2019, 11:33 PM UTC (55e0582)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/189/af6c432...55e0582.html" title="Last updated on Aug 20, 2019, 11:33 PM UTC (55e0582)">Diff</a>