### PR TITLE
Adds Security UI Considerations.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -305,25 +305,8 @@ it has been truncated.
 Advertising agents must follow the mDNS [=conflict resolution=] procedure, to
 prevent multiple advertising agents from using the same DNS-SD Instance Name.
 
-Agents must treat Instance Names as unverified information, and should check
-that the Instance Name is a prefix of the display name received through the
-`agent-info` message after a successful QUIC connection.  Once an agent has done
-this check, it can show the name as a <dfn noexport>verified display name</dfn>.
-
-Agents should show only complete display names to the user, instead of truncated
-display names from DNS-SD.  A truncated display name should be verified as above
-before being shown in full as a [=verified display name=].
-
-<div class="note">
-This means there are three categories of display names that agents should be
-capable of handling:
-<ol>
-  <li>Truncated and unverified DNS-SD Instance Names, which should not be shown to the user.</li>
-  <li>Complete but unverified DNS-SD Instance Names, which can be shown as
-     unverified prior to [[#authentication]].</li>
-  <li>Verified display names.</li>
-</ol>
-</div>
+Agents should be careful when displaying Instance Names to users; see
+[[#instance-names]] for guidelines on Instance Name display.
 
 Advertising agents must include DNS TXT records with the following
 keys and values:
@@ -1726,7 +1709,7 @@ exchanged between agents.  They can inject traffic into existing QUIC
 connections and attempt to initiate new QUIC connections.  These abilities can
 be used to attempt the following:
 
-*   Impersonate an agent or one already trusted by the user, in an attempt
+*   Impersonate an agent or one already authenticated by the user, in an attempt
     to convince the user to authenticate to it.
 *   Connect to an agent and query its capabilities.
 *   Connect to and control a presentation or remote playback, or extract data
@@ -1908,15 +1891,18 @@ Local active attackers may attempt to impersonate a presentation display the
 user would normally trust.  The [[#authentication]] step of the Open Screen
 Protocol prevents a man-in-the-middle from impersonating an agent, without
 knowledge of a shared secret.  However, it is possible for an attacker to
-impersonate an existing, trusted display or a newly discovered display that is
-not yet authenticated and try to convince the user to authenticate it.
+impersonate an existing, trusted agent or a newly discovered agent that is not
+yet authenticated and try to convince the user to authenticate to it.  (Trust in
+this context means that a user has completed [[#authentication]] from their
+agent to another agent.)
 
 This can be addressed through a combination of techniques.  The first is
-detecting and flagging attempts at impersonation; a few of the situations that
-should be flagged include:
+detecting attempts at impersonation.  Agents should detect the following
+situations and flag an agent that meets any of the criteria as a <dfn>suspicious
+agent</dfn>:
 
-* Untrusted agents whose public key fingerprint collides with that from an
-    already-trusted agent that is concurrently being advertised.
+* Agents with distinct IP endpoints whose public key fingerprints collide during
+    concurrent advertisement.
 * Untrusted agents whose display name differs from the one previously
     advertised under a given public key fingerprint.
 * Untrusted agents that fail the authentication challenge a certain number of times.
@@ -1925,12 +1911,6 @@ should be flagged include:
 * Already-trusted agents whose metadata provided through the `agent-info`
     message has changed.
 
-Flagging means that the user is notified of the attempt at impersonation.  In
-the last case, the user should be required to re-authenticate to the
-already-trusted agent to verify its identity.
-
-Issue(118): UI guidelines for pairing and trusted/untrusted data.
-
 The second is through management of the low-entropy secret during mutual
 authentication:
 
@@ -1938,8 +1918,6 @@ authentication:
 * Use an increasing backoff to respond to authentication challenges, also to
     prevent brute force attacks.
 * Use a cryptographically sound source of entropy to generate the shared secret.
-* Require the end user to manually type the shared secret - shown only on the
-    display - to prevent the user from blindly clicking through this step.
 
 The active attacker may also attempt to disrupt data exchanged over the QUIC
 connection by injecting or modifying traffic.  These attacks should be mitigated
@@ -1981,6 +1959,52 @@ components) should use defense-in-depth techniques like <a
 href="https://en.wikipedia.org/wiki/Sandbox_(computer_security)">sandboxing</a>
 to prevent vulnerabilities from gaining access to user data or leading to
 persistent exploits.
+
+User Interface Considerations {#security-ui}
+-----------------------------
+
+This specification does make any specific requirements of the security relevant
+user interfaces of Open Screen agents.  However there are important
+considerations when designing these user interfaces, as PSK based authentication
+requires users to make informed decisions about which agents to trust.
+
+1. Before an agent has authenticated another device, the agent should make it
+    clear that any `agent-info` or other data from that device has not been
+    verified by authentication.  (See below for how this applies to DNS-SD
+    Instance Names.)
+1. An [=suspicious agent=] should be displayed differently from trusted
+    agents that are not suspicious, or not displayed at all.
+1. The user interface to input a PSK during authentication should be done in
+    trusted UI and be difficult to spoof.
+1. The user should be required to take action to input the PSK, to prevent the
+    user from blindly clicking through this step.
+1. The user interfaces to render and input a PSK should meet accessibility
+    guidelines.
+
+### Instance and Display Names  ### {#instance-names}
+
+Because DNS-SD [=Instance Names=] are the the primary information that the user
+sees prior to authentication, careful presentation of these names is necessary.
+
+Agents must treat Instance Names as unverified information, and should check
+that the Instance Name is a prefix of the display name received through the
+`agent-info` message after a successful QUIC connection.  Once an agent has done
+this check, it can show the name as a <dfn noexport>verified display name</dfn>.
+
+Agents should show only complete display names to the user, instead of truncated
+display names from DNS-SD.  A truncated display name should be verified as above
+before being shown in full as a [=verified display name=].
+
+<div class="note">
+This means there are three categories of display names that agents should be
+capable of handling:
+<ol>
+  <li>Truncated and unverified DNS-SD Instance Names, which should not be shown to the user.</li>
+  <li>Complete but unverified DNS-SD Instance Names, which can be shown as
+     unverified prior to [[#authentication]].</li>
+  <li>Verified display names.</li>
+</ol>
+</div>
 
 Appendix A: Messages {#appendix-a}
 ====================

--- a/index.bs
+++ b/index.bs
@@ -1963,8 +1963,8 @@ persistent exploits.
 User Interface Considerations {#security-ui}
 -----------------------------
 
-This specification does make any specific requirements of the security relevant
-user interfaces of Open Screen agents.  However there are important
+This specification does not make any specific requirements of the security
+relevant user interfaces of Open Screen agents.  However there are important
 considerations when designing these user interfaces, as PSK based authentication
 requires users to make informed decisions about which agents to trust.
 
@@ -1972,7 +1972,7 @@ requires users to make informed decisions about which agents to trust.
     clear that any `agent-info` or other data from that device has not been
     verified by authentication.  (See below for how this applies to DNS-SD
     Instance Names.)
-1. An [=suspicious agent=] should be displayed differently from trusted
+1. A [=suspicious agent=] should be displayed differently from trusted
     agents that are not suspicious, or not displayed at all.
 1. The user interface to input a PSK during authentication should be done in
     trusted UI and be difficult to spoof.
@@ -1983,7 +1983,7 @@ requires users to make informed decisions about which agents to trust.
 
 ### Instance and Display Names  ### {#instance-names}
 
-Because DNS-SD [=Instance Names=] are the the primary information that the user
+Because DNS-SD [=Instance Names=] are the primary information that the user
 sees prior to authentication, careful presentation of these names is necessary.
 
 Agents must treat Instance Names as unverified information, and should check

--- a/index.bs
+++ b/index.bs
@@ -1970,7 +1970,7 @@ User Interface Considerations {#security-ui}
 
 This specification does not make any specific requirements of the security
 relevant user interfaces of Open Screen agents.  However there are important
-considerations when designing these user interfaces, as PSK based authentication
+considerations when designing these user interfaces, as PSK-based authentication
 requires users to make informed decisions about which agents to trust.
 
 1. Before an agent has authenticated another device, the agent should make it

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="31226ab5709d7694feb6784fde0aae502032c3e5" name="document-revision">
+  <meta content="a13934971eb79970c3c9f71fcc5046037a7c80b9" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-23">23 August 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-27">27 August 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1576,6 +1576,11 @@ pre .property::before, pre .property::after {
         <li><a href="#remote-active-mitigations"><span class="secno">12.5.3</span> <span class="content">Remote active network attackers</span></a>
         <li><a href="#denial-of-service-mitigations"><span class="secno">12.5.4</span> <span class="content">Denial of service</span></a>
         <li><a href="#malicious-input-mitigations"><span class="secno">12.5.5</span> <span class="content">Malicious input</span></a>
+       </ol>
+      <li>
+       <a href="#security-ui"><span class="secno">12.6</span> <span class="content">User Interface Considerations</span></a>
+       <ol class="toc">
+        <li><a href="#instance-names"><span class="secno">12.6.1</span> <span class="content">Instance and Display Names</span></a>
        </ol>
      </ol>
     <li><a href="#appendix-a"><span class="secno"></span> <span class="content">Appendix A: Messages</span></a>
@@ -1791,22 +1796,7 @@ must be terminated by a null (<code>\000</code>) character, so that a listening 
 it has been truncated.</p>
    <p>Advertising agents must follow the mDNS <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6762#section-9" id="ref-for-section-9">conflict resolution</a> procedure, to
 prevent multiple advertising agents from using the same DNS-SD Instance Name.</p>
-   <p>Agents must treat Instance Names as unverified information, and should check
-that the Instance Name is a prefix of the display name received through the <code>agent-info</code> message after a successful QUIC connection.  Once an agent has done
-this check, it can show the name as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="verified-display-name">verified display name</dfn>.</p>
-   <p>Agents should show only complete display names to the user, instead of truncated
-display names from DNS-SD.  A truncated display name should be verified as above
-before being shown in full as a <a data-link-type="dfn" href="#verified-display-name" id="ref-for-verified-display-name">verified display name</a>.</p>
-   <div class="note" role="note">
-     This means there are three categories of display names that agents should be
-capable of handling: 
-    <ol>
-     <li>Truncated and unverified DNS-SD Instance Names, which should not be shown to the user.
-     <li>Complete but unverified DNS-SD Instance Names, which can be shown as
-     unverified prior to <a href="#authentication">§ 6 Authentication</a>.
-     <li>Verified display names.
-    </ol>
-   </div>
+   <p>Agents should be careful when displaying Instance Names to users; see <a href="#instance-names">§ 12.6.1 Instance and Display Names</a> for guidelines on Instance Name display.</p>
    <p>Advertising agents must include DNS TXT records with the following
 keys and values:</p>
    <dl>
@@ -2986,7 +2976,7 @@ connections and attempt to initiate new QUIC connections.  These abilities can
 be used to attempt the following:</p>
    <ul>
     <li data-md>
-     <p>Impersonate an agent or one already trusted by the user, in an attempt
+     <p>Impersonate an agent or one already authenticated by the user, in an attempt
 to convince the user to authenticate to it.</p>
     <li data-md>
      <p>Connect to an agent and query its capabilities.</p>
@@ -3143,15 +3133,18 @@ cryptographic parameters of the TLS 1.3 QUIC connection.</p>
 user would normally trust.  The <a href="#authentication">§ 6 Authentication</a> step of the Open Screen
 Protocol prevents a man-in-the-middle from impersonating an agent, without
 knowledge of a shared secret.  However, it is possible for an attacker to
-impersonate an existing, trusted display or a newly discovered display that is
-not yet authenticated and try to convince the user to authenticate it.</p>
+impersonate an existing, trusted agent or a newly discovered agent that is not
+yet authenticated and try to convince the user to authenticate to it.  (Trust in
+this context means that a user has completed <a href="#authentication">§ 6 Authentication</a> from their
+agent to another agent.)</p>
    <p>This can be addressed through a combination of techniques.  The first is
-detecting and flagging attempts at impersonation; a few of the situations that
-should be flagged include:</p>
+detecting attempts at impersonation.  Agents should detect the following
+situations and flag an agent that meets any of the criteria as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="suspicious agent" data-noexport id="suspicious-agent">suspicious
+agent</dfn>:</p>
    <ul>
     <li data-md>
-     <p>Untrusted agents whose public key fingerprint collides with that from an
-already-trusted agent that is concurrently being advertised.</p>
+     <p>Agents with distinct IP endpoints whose public key fingerprints collide during
+concurrent advertisement.</p>
     <li data-md>
      <p>Untrusted agents whose display name differs from the one previously
 advertised under a given public key fingerprint.</p>
@@ -3163,10 +3156,6 @@ already-trusted agent.</p>
     <li data-md>
      <p>Already-trusted agents whose metadata provided through the <code>agent-info</code> message has changed.</p>
    </ul>
-   <p>Flagging means that the user is notified of the attempt at impersonation.  In
-the last case, the user should be required to re-authenticate to the
-already-trusted agent to verify its identity.</p>
-   <p class="issue" id="issue-d435d3a9"><a class="self-link" href="#issue-d435d3a9"></a> UI guidelines for pairing and trusted/untrusted data. <a href="https://github.com/webscreens/openscreenprotocol/issues/118">&lt;https://github.com/webscreens/openscreenprotocol/issues/118></a></p>
    <p>The second is through management of the low-entropy secret during mutual
 authentication:</p>
    <ul>
@@ -3177,9 +3166,6 @@ authentication:</p>
 prevent brute force attacks.</p>
     <li data-md>
      <p>Use a cryptographically sound source of entropy to generate the shared secret.</p>
-    <li data-md>
-     <p>Require the end user to manually type the shared secret - shown only on the
-display - to prevent the user from blindly clicking through this step.</p>
    </ul>
    <p>The active attacker may also attempt to disrupt data exchanged over the QUIC
 connection by injecting or modifying traffic.  These attacks should be mitigated
@@ -3209,6 +3195,49 @@ like <a href="https://en.wikipedia.org/wiki/Fuzzing">fuzz testing</a>.</p>
    <p>Where possible, Open Screen Protocol agents (including the content rendering
 components) should use defense-in-depth techniques like <a href="https://en.wikipedia.org/wiki/Sandbox_(computer_security)">sandboxing</a> to prevent vulnerabilities from gaining access to user data or leading to
 persistent exploits.</p>
+   <h3 class="heading settled" data-level="12.6" id="security-ui"><span class="secno">12.6. </span><span class="content">User Interface Considerations</span><a class="self-link" href="#security-ui"></a></h3>
+   <p>This specification does make any specific requirements of the security relevant
+user interfaces of Open Screen agents.  However there are important
+considerations when designing these user interfaces, as PSK based authentication
+requires users to make informed decisions about which agents to trust.</p>
+   <ol>
+    <li data-md>
+     <p>Before an agent has authenticated another device, the agent should make it
+clear that any <code>agent-info</code> or other data from that device has not been
+verified by authentication.  (See below for how this applies to DNS-SD
+Instance Names.)</p>
+    <li data-md>
+     <p>An <a data-link-type="dfn" href="#suspicious-agent" id="ref-for-suspicious-agent">suspicious agent</a> should be displayed differently from trusted
+agents that are not suspicious, or not displayed at all.</p>
+    <li data-md>
+     <p>The user interface to input a PSK during authentication should be done in
+trusted UI and be difficult to spoof.</p>
+    <li data-md>
+     <p>The user should be required to take action to input the PSK, to prevent the
+user from blindly clicking through this step.</p>
+    <li data-md>
+     <p>The user interfaces to render and input a PSK should meet accessibility
+guidelines.</p>
+   </ol>
+   <h4 class="heading settled" data-level="12.6.1" id="instance-names"><span class="secno">12.6.1. </span><span class="content">Instance and Display Names</span><a class="self-link" href="#instance-names"></a></h4>
+   <p>Because DNS-SD <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6763#section-4.1.1" id="ref-for-section-4.1.1①">Instance Names</a> are the the primary information that the user
+sees prior to authentication, careful presentation of these names is necessary.</p>
+   <p>Agents must treat Instance Names as unverified information, and should check
+that the Instance Name is a prefix of the display name received through the <code>agent-info</code> message after a successful QUIC connection.  Once an agent has done
+this check, it can show the name as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="verified-display-name">verified display name</dfn>.</p>
+   <p>Agents should show only complete display names to the user, instead of truncated
+display names from DNS-SD.  A truncated display name should be verified as above
+before being shown in full as a <a data-link-type="dfn" href="#verified-display-name" id="ref-for-verified-display-name">verified display name</a>.</p>
+   <div class="note" role="note">
+     This means there are three categories of display names that agents should be
+capable of handling: 
+    <ol>
+     <li>Truncated and unverified DNS-SD Instance Names, which should not be shown to the user.
+     <li>Complete but unverified DNS-SD Instance Names, which can be shown as
+     unverified prior to <a href="#authentication">§ 6 Authentication</a>.
+     <li>Verified display names.
+    </ol>
+   </div>
    <h2 class="heading settled" id="appendix-a"><span class="content">Appendix A: Messages</span><a class="self-link" href="#appendix-a"></a></h2>
    <p>The following messages are defined with <a data-link-type="biblio" href="#biblio-cddl">[CDDL]</a>. When integer keys are used, a
 comment is appended to the line to indicate the name of the field. Object
@@ -3984,7 +4013,8 @@ extensions.</p>
    <li><a href="#presentation-url-availability-event">presentation-url-availability-event</a><span>, in §Unnumbered section</span>
    <li><a href="#presentation-url-availability-request">presentation-url-availability-request</a><span>, in §Unnumbered section</span>
    <li><a href="#presentation-url-availability-response">presentation-url-availability-response</a><span>, in §Unnumbered section</span>
-   <li><a href="#verified-display-name">verified display name</a><span>, in §3</span>
+   <li><a href="#suspicious-agent">suspicious agent</a><span>, in §12.5.2</span>
+   <li><a href="#verified-display-name">verified display name</a><span>, in §12.6.1</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-htmlmediaelement">
    <a href="https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement">https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement</a><b>Referenced in:</b>
@@ -4136,6 +4166,7 @@ extensions.</p>
    <a href="https://tools.ietf.org/html/rfc6763#section-4.1.1">https://tools.ietf.org/html/rfc6763#section-4.1.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.1.1">3. Discovery with mDNS</a>
+    <li><a href="#ref-for-section-4.1.1①">12.6.1. Instance and Display Names</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-section-7">
@@ -4253,7 +4284,6 @@ implementation specific mechanism, quote that here and map it to a message.<a hr
    <div class="issue"> Fate of metadata / authentication history when clearing browsing data. <a href="https://github.com/webscreens/openscreenprotocol/issues/132">&lt;https://github.com/webscreens/openscreenprotocol/issues/132></a><a href="#issue-8bf4aa9f"> ↵ </a></div>
    <div class="issue"> Notify endpoints when new connection is created. <a href="https://github.com/webscreens/openscreenprotocol/issues/143">&lt;https://github.com/webscreens/openscreenprotocol/issues/143></a><a href="#issue-edc1d8c1"> ↵ </a></div>
    <div class="issue"> Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a><a href="#issue-84520e29"> ↵ </a></div>
-   <div class="issue"> UI guidelines for pairing and trusted/untrusted data. <a href="https://github.com/webscreens/openscreenprotocol/issues/118">&lt;https://github.com/webscreens/openscreenprotocol/issues/118></a><a href="#issue-d435d3a9"> ↵ </a></div>
    <div class="issue"> Review attack and mitigation considerations for TLS 1.3 <a href="https://github.com/webscreens/openscreenprotocol/issues/130">&lt;https://github.com/webscreens/openscreenprotocol/issues/130></a><a href="#issue-84520e29①"> ↵ </a></div>
   </div>
   <aside class="dfn-panel" data-for="advertising-agent">
@@ -4262,10 +4292,16 @@ implementation specific mechanism, quote that here and map it to a message.<a hr
     <li><a href="#ref-for-advertising-agent">6. Authentication</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="suspicious-agent">
+   <b><a href="#suspicious-agent">#suspicious-agent</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-suspicious-agent">12.6. User Interface Considerations</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="verified-display-name">
    <b><a href="#verified-display-name">#verified-display-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-verified-display-name">3. Discovery with mDNS</a>
+    <li><a href="#ref-for-verified-display-name">12.6.1. Instance and Display Names</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="presentation-url-availability-request">

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="a13934971eb79970c3c9f71fcc5046037a7c80b9" name="document-revision">
+  <meta content="64a6856f943a2ac1125ca232d28bdb2e5b864094" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-27">27 August 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-28">28 August 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -3196,8 +3196,8 @@ like <a href="https://en.wikipedia.org/wiki/Fuzzing">fuzz testing</a>.</p>
 components) should use defense-in-depth techniques like <a href="https://en.wikipedia.org/wiki/Sandbox_(computer_security)">sandboxing</a> to prevent vulnerabilities from gaining access to user data or leading to
 persistent exploits.</p>
    <h3 class="heading settled" data-level="12.6" id="security-ui"><span class="secno">12.6. </span><span class="content">User Interface Considerations</span><a class="self-link" href="#security-ui"></a></h3>
-   <p>This specification does make any specific requirements of the security relevant
-user interfaces of Open Screen agents.  However there are important
+   <p>This specification does not make any specific requirements of the security
+relevant user interfaces of Open Screen agents.  However there are important
 considerations when designing these user interfaces, as PSK based authentication
 requires users to make informed decisions about which agents to trust.</p>
    <ol>
@@ -3207,7 +3207,7 @@ clear that any <code>agent-info</code> or other data from that device has not be
 verified by authentication.  (See below for how this applies to DNS-SD
 Instance Names.)</p>
     <li data-md>
-     <p>An <a data-link-type="dfn" href="#suspicious-agent" id="ref-for-suspicious-agent">suspicious agent</a> should be displayed differently from trusted
+     <p>A <a data-link-type="dfn" href="#suspicious-agent" id="ref-for-suspicious-agent">suspicious agent</a> should be displayed differently from trusted
 agents that are not suspicious, or not displayed at all.</p>
     <li data-md>
      <p>The user interface to input a PSK during authentication should be done in
@@ -3220,7 +3220,7 @@ user from blindly clicking through this step.</p>
 guidelines.</p>
    </ol>
    <h4 class="heading settled" data-level="12.6.1" id="instance-names"><span class="secno">12.6.1. </span><span class="content">Instance and Display Names</span><a class="self-link" href="#instance-names"></a></h4>
-   <p>Because DNS-SD <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6763#section-4.1.1" id="ref-for-section-4.1.1①">Instance Names</a> are the the primary information that the user
+   <p>Because DNS-SD <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6763#section-4.1.1" id="ref-for-section-4.1.1①">Instance Names</a> are the primary information that the user
 sees prior to authentication, careful presentation of these names is necessary.</p>
    <p>Agents must treat Instance Names as unverified information, and should check
 that the Instance Name is a prefix of the display name received through the <code>agent-info</code> message after a successful QUIC connection.  Once an agent has done

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="07fe72013f4c166c397252c4041600c7e3d7f414" name="document-revision">
+  <meta content="70d6070cc3e111a0f1e82882a4c7274328f84645" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-28">28 August 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-29">29 August 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -3200,7 +3200,7 @@ persistent exploits.</p>
    <h3 class="heading settled" data-level="12.6" id="security-ui"><span class="secno">12.6. </span><span class="content">User Interface Considerations</span><a class="self-link" href="#security-ui"></a></h3>
    <p>This specification does not make any specific requirements of the security
 relevant user interfaces of Open Screen agents.  However there are important
-considerations when designing these user interfaces, as PSK based authentication
+considerations when designing these user interfaces, as PSK-based authentication
 requires users to make informed decisions about which agents to trust.</p>
    <ol>
     <li data-md>


### PR DESCRIPTION
This PR addresses Issue #118: UI guidelines for pairing and trusted/untrusted data.  
Action from the Berlin F2F: https://www.w3.org/2019/05/23-webscreens-minutes.html#x21

It adds a Security UI Considerations section with general guidelines on how metadata from agents should be presented to the user, and on PSK display and input. 

It also defines a "suspicious agent" as one that meets a criterion for a potential MITM attack.  The details on how to display a suspicious agent are moved to Security UI Considerations.

It also moves the description of how Instance Names should be handled into Security UI Considerations.

Finally it clarifies that any agents advertising a public key FP collision should be treated as suspicious (trusted or not) since we won't have any way to tell them apart.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/pull/197.html" title="Last updated on Aug 30, 2019, 3:28 AM UTC (78eebc7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/197/8e25af6...78eebc7.html" title="Last updated on Aug 30, 2019, 3:28 AM UTC (78eebc7)">Diff</a>