### PR TITLE
Adds an initial capabilities registry.

### DIFF
--- a/capabilities.md
+++ b/capabilities.md
@@ -13,14 +13,14 @@ Screen Protocol](https://webscreens.github.io/openscreenprotocol/#transport).
 
 | Id |     Name                  |         Description         | Message Type IDs      |
 |----|---------------------------|-----------------------------|-----------------------|
-| 1  | `receive-audio`           | Renders audio               | n/a                   |
-| 2  | `receive-video`           | Renders video               | n/a                   |
+| 1  | `receive-audio`           | Audio Receiver              | 22                    |
+| 2  | `receive-video`           | Video Receiver              | 23                    |
 | 3  | `receive-presentation`    | Presentation API Receiver   | 14,16,104,106,109,113 |
 | 4  | `control-presentation`    | Presentation API Controller | 15,16,103,105,107,108,110,113,121 |
 | 5  | `receive-remote-playback` | Remote Playback Receiver    | 17,115,117,119        |
 | 6  | `control-remote-playback` | Remote Playback Controller  | 18,20,21,114,116,118  |
-| 7  | `receive-streaming`       | Receive media/data frames   | 22,23,24              |
-| 8  | `send-streaming`          | Send media/data frames      |                       |
+| 7  | `receive-streaming`       | Streaming Receiver          | 24                    |
+| 8  | `send-streaming`          | Streaming Sender            |                       |
 
 
 ## Extension Capabilities
@@ -33,7 +33,7 @@ extension.)
 
 | Id   |     Name            | Organization  | Description            | Message Type IDs      |
 |------|---------------------|---------------|------------------------|-----------------------|
-| 1000 | `frobinate-xyzzy`   | FrobozzCo     | Adds xyzzy capability  | 49-51, 8,193-8,199    |
+| 1000 | `frobinate-xyzzy`   | FrobozzCo     | Adds xyzzy capability  | 49-51, 8193-8199      |
 
 
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -1,8 +1,8 @@
 # Open Screen Protocol Capabilities Registry
 
-This registry lists the known capability values used by the [Open Screen
+This registry lists the known protocol capabilities used in the [Open Screen
 Protocol](https://webscreens.github.io/openscreenprotocol/).  An Open Screen
-agent uses capabilities to inform other agents of what protocol message types it
+agent uses capabilities to inform other agents which protocol messages it
 understands.
 
 Capability values 1-999 are reserved for use by the Open Screen Protocol itself.
@@ -22,16 +22,18 @@ Screen Protocol](https://webscreens.github.io/openscreenprotocol/#transport).
 | 7  | `receive-streaming`       | Receive media/data frames   | 22,23,24              |
 | 8  | `send-streaming`          | Send media/data frames      |                       |
 
+
 ## Extension Capabilities
 
-This table lists capabilities that are extensions of the core protocol.  Each
-extension should reserve a range of message type IDs and/or a list of additional
-fields that will be added to existing Open Screen Messages. (The entry below is
-just an example and not an actual registered extension.)
+This table lists capabilities that other parties have reserved to extend the
+core protoco.  Each extension should reserve a range of message type IDs and/or
+a list of additional fields that will be added to existing Open Screen
+Messages. (The entry below is just an example and not an actual registered
+extension.)
 
-| Id   |     Name                  |         Description         | Message Type IDs      |
-|------|---------------------------|-----------------------------|-----------------------|
-| 1000 | `xyzzy-frobinate`         | Adds xyzzy capability       | 49-51, 8,193-8,199    |
+| Id   |     Name            | Organization  | Description            | Message Type IDs      |
+|------|---------------------|---------------|------------------------|-----------------------|
+| 1000 | `frobinate-xyzzy`   | FrobozzCo     | Adds xyzzy capability  | 49-51, 8,193-8,199    |
 
 
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -1,0 +1,38 @@
+# Open Screen Protocol Capabilities Registry
+
+This registry lists the known capability values used by the [Open Screen
+Protocol](https://webscreens.github.io/openscreenprotocol/).  An Open Screen
+agent uses capabilities to inform other agents of what protocol message types it
+understands.
+
+Capability values 1-999 are reserved for use by the Open Screen Protocol itself.
+They are listed here for completeness, but are more fully described in the [Open
+Screen Protocol](https://webscreens.github.io/openscreenprotocol/#transport).
+
+## Open Screen Protocol Capabilities
+
+| Id |     Name                  |         Description         | Message Type IDs      |
+|----|---------------------------|-----------------------------|-----------------------|
+| 1  | `receive-audio`           | Renders audio               | n/a                   |
+| 2  | `receive-video`           | Renders video               | n/a                   |
+| 3  | `receive-presentation`    | Presentation API Receiver   | 14,16,104,106,109,113 |
+| 4  | `control-presentation`    | Presentation API Controller | 15,16,103,105,107,108,110,113,121 |
+| 5  | `receive-remote-playback` | Remote Playback Receiver    | 17,115,117,119        |
+| 6  | `control-remote-playback` | Remote Playback Controller  | 18,20,21,114,116,118  |
+| 7  | `receive-streaming`       | Receive media/data frames   | 22,23,24              |
+| 8  | `send-streaming`          | Send media/data frames      |                       |
+
+## Extension Capabilities
+
+This table lists capabilities that are extensions of the core protocol.  Each
+extension should reserve a range of message type IDs and/or a list of additional
+fields that will be added to existing Open Screen Messages. (The entry below is
+just an example and not an actual registered extension.)
+
+| Id   |     Name                  |         Description         | Message Type IDs      |
+|------|---------------------------|-----------------------------|-----------------------|
+| 1000 | `xyzzy-frobinate`         | Adds xyzzy capability       | 49-51, 8,193-8,199    |
+
+
+
+

--- a/capabilities.md
+++ b/capabilities.md
@@ -26,7 +26,7 @@ Screen Protocol](https://webscreens.github.io/openscreenprotocol/#transport).
 ## Extension Capabilities
 
 This table lists capabilities that other parties have reserved to extend the
-core protoco.  Each extension should reserve a range of message type IDs and/or
+core protocol.  Each extension should reserve a range of message type IDs and/or
 a list of additional fields that will be added to existing Open Screen
 Messages. (The entry below is just an example and not an actual registered
 extension.)

--- a/index.bs
+++ b/index.bs
@@ -443,6 +443,11 @@ The various capabilities have the following meanings:
 : send-streaming
 :: The agent can send streaming using the streaming protocol.
 
+Note: See the
+[Capabilities Registry](https://webscreens.github.io/openscreenprotocol/capabilities.md)
+for a list of all known capabilities (both defined by this specification, and
+through [[#protocol-extensions]]).
+
 
 Listening agents act as QUIC clients.  Advertising agents act as QUIC servers.
 
@@ -1652,10 +1657,11 @@ specification.  This could be used for experimentation, customization or other
 purposes.
 
 To add new extension messages, extension authors must register a capability ID
-with a range of message type keys in a public registry (location to be
-determined).  Agents may then indicate that they accept an extension by
-including the corresponding capability ID in the `capabilities` field of its
-`agent-info` message.
+with a range of message type keys in a
+[public registry](https://webscreens.github.io/openscreenprotocol/capabilites.md).
+Agents may then indicate that they accept an extension by including the
+corresponding capability ID in the `capabilities` field of its `agent-info`
+message.
 
 Capability IDs 1-999 are reserved for use by the Open Screen Protocol.
 Capability IDs 1000 and above are available for extensions.  See [[#appendix-b]]

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="31226ab5709d7694feb6784fde0aae502032c3e5" name="document-revision">
+  <meta content="7ad68cea41a6b1ded846ed30279e1e6a8f680f26" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1466,7 +1466,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Open Screen Protocol</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-23">23 August 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-08-27">27 August 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1916,6 +1916,8 @@ protocol.</p>
     <dd data-md>
      <p>The agent can send streaming using the streaming protocol.</p>
    </dl>
+   <p class="note" role="note"><span>Note:</span> See the <a href="https://webscreens.github.io/openscreenprotocol/capabilities.md">Capabilities Registry</a> for a list of all known capabilities (both defined by this specification, and
+through <a href="#protocol-extensions">§ 11 Protocol Extensions</a>).</p>
    <p>Listening agents act as QUIC clients.  Advertising agents act as QUIC servers.</p>
    <p>If a listening agent wishes to receive messages from an advertising agent or an
 advertising agent wishes to send messages to a listening agent, it may wish to
@@ -2936,9 +2938,9 @@ certificate fingerprint) to track requests across multiple agents.</p>
 specification.  This could be used for experimentation, customization or other
 purposes.</p>
    <p>To add new extension messages, extension authors must register a capability ID
-with a range of message type keys in a public registry (location to be
-determined).  Agents may then indicate that they accept an extension by
-including the corresponding capability ID in the <code>capabilities</code> field of its <code>agent-info</code> message.</p>
+with a range of message type keys in a <a href="https://webscreens.github.io/openscreenprotocol/capabilites.md">public registry</a>.
+Agents may then indicate that they accept an extension by including the
+corresponding capability ID in the <code>capabilities</code> field of its <code>agent-info</code> message.</p>
    <p>Capability IDs 1-999 are reserved for use by the Open Screen Protocol.
 Capability IDs 1000 and above are available for extensions.  See <a href="#appendix-b">Appendix B: Message Type Key Ranges</a> for legal ranges for extension message type keys.</p>
    <p class="note" role="note"><span>Note:</span> The purpose of the public registry is to prevent conflicts between
@@ -3237,12 +3239,12 @@ the wire smaller.</p>
 <p><span class="nc">agent-capability </span><span class="p">=</span> <span class="o">&amp;</span><span class="p">(</span>
   <span class="nx">receive-audio</span><span class="p">:</span> <span class="mi">1</span>
   <span class="nx">receive-video</span><span class="p">:</span> <span class="mi">2</span>
-  <span class="nx">receive-presentation</span><span class="p">:</span> <span class="mi">2</span>
-  <span class="nx">control-presentation</span><span class="p">:</span> <span class="mi">3</span>
-  <span class="nx">receive-remote-playback</span><span class="p">:</span> <span class="mi">4</span>
-  <span class="nx">control-remote-playback</span><span class="p">:</span> <span class="mi">5</span>
-  <span class="nx">receive-streaming</span><span class="p">:</span> <span class="mi">6</span>
-  <span class="nx">send-streaming</span><span class="p">:</span> <span class="mi">7</span>
+  <span class="nx">receive-presentation</span><span class="p">:</span> <span class="mi">3</span>
+  <span class="nx">control-presentation</span><span class="p">:</span> <span class="mi">4</span>
+  <span class="nx">receive-remote-playback</span><span class="p">:</span> <span class="mi">5</span>
+  <span class="nx">control-remote-playback</span><span class="p">:</span> <span class="mi">6</span>
+  <span class="nx">receive-streaming</span><span class="p">:</span> <span class="mi">7</span>
+  <span class="nx">send-streaming</span><span class="p">:</span> <span class="mi">8</span>
 <span class="p">)</span></p>
 
 <p><span class="nc">agent-info </span><span class="p">=</span> <span class="p">{</span>

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -12,12 +12,12 @@ agent-info-response = {
 agent-capability = &(
   receive-audio: 1
   receive-video: 2
-  receive-presentation: 2
-  control-presentation: 3
-  receive-remote-playback: 4
-  control-remote-playback: 5
-  receive-streaming: 6
-  send-streaming: 7
+  receive-presentation: 3
+  control-presentation: 4
+  receive-remote-playback: 5
+  control-remote-playback: 6
+  receive-streaming: 7
+  send-streaming: 8
 )
 
 agent-info = {

--- a/messages_appendix.html
+++ b/messages_appendix.html
@@ -12,12 +12,12 @@
 <span class="nc">agent-capability </span><span class="p">=</span> <span class="o">&amp;</span><span class="p">(</span>
   <span class="nx">receive-audio</span><span class="p">:</span> <span class="mi">1</span>
   <span class="nx">receive-video</span><span class="p">:</span> <span class="mi">2</span>
-  <span class="nx">receive-presentation</span><span class="p">:</span> <span class="mi">2</span>
-  <span class="nx">control-presentation</span><span class="p">:</span> <span class="mi">3</span>
-  <span class="nx">receive-remote-playback</span><span class="p">:</span> <span class="mi">4</span>
-  <span class="nx">control-remote-playback</span><span class="p">:</span> <span class="mi">5</span>
-  <span class="nx">receive-streaming</span><span class="p">:</span> <span class="mi">6</span>
-  <span class="nx">send-streaming</span><span class="p">:</span> <span class="mi">7</span>
+  <span class="nx">receive-presentation</span><span class="p">:</span> <span class="mi">3</span>
+  <span class="nx">control-presentation</span><span class="p">:</span> <span class="mi">4</span>
+  <span class="nx">receive-remote-playback</span><span class="p">:</span> <span class="mi">5</span>
+  <span class="nx">control-remote-playback</span><span class="p">:</span> <span class="mi">6</span>
+  <span class="nx">receive-streaming</span><span class="p">:</span> <span class="mi">7</span>
+  <span class="nx">send-streaming</span><span class="p">:</span> <span class="mi">8</span>
 <span class="p">)</span>
 
 <span class="nc">agent-info </span><span class="p">=</span> <span class="p">{</span>


### PR DESCRIPTION
This is a markdown file listing known capabilities and their corresponding messages. 
Extensions could register their messages by adding to this file.

It also fixes duplicate numbering in the definition of `agent-capability` and adds links from the main spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/pull/198.html" title="Last updated on Aug 28, 2019, 11:22 PM UTC (8e25af6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/198/4c4b287...8e25af6.html" title="Last updated on Aug 28, 2019, 11:22 PM UTC (8e25af6)">Diff</a>