### PR TITLE
Adds an additional security UI guideline for PSK presentation.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1986,6 +1986,9 @@ requires users to make informed decisions about which agents to trust.
     Instance Names.)
 1. A [=suspicious agent=] should be displayed differently from trusted
     agents that are not suspicious, or not displayed at all.
+1. The user interface to present a PSK during authentication should be done in
+    trusted UI and be difficult to spoof.  It should be clear to the user which
+    physical device is presenting the PSK.
 1. The user interface to input a PSK during authentication should be done in
     trusted UI and be difficult to spoof.
 1. The user should be required to take action to input the PSK, to prevent the

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="b222800ecaab84c3d30a47ada2054f99e6473f8f" name="document-revision">
+  <meta content="d5f63863d4ffe819fa73e6e3fdf3cdf4e80d77b6" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -3187,6 +3187,10 @@ Instance Names.)</p>
     <li data-md>
      <p>A <a data-link-type="dfn" href="#suspicious-agent" id="ref-for-suspicious-agent">suspicious agent</a> should be displayed differently from trusted
 agents that are not suspicious, or not displayed at all.</p>
+    <li data-md>
+     <p>The user interface to present a PSK during authentication should be done in
+trusted UI and be difficult to spoof.  It should be clear to the user which
+physical device is presenting the PSK.</p>
     <li data-md>
      <p>The user interface to input a PSK during authentication should be done in
 trusted UI and be difficult to spoof.</p>


### PR DESCRIPTION
To finish drafting spec material for Issue #118: UI guidelines for pairing and trusted/untrusted data.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/pull/202.html" title="Last updated on Aug 30, 2019, 3:36 AM UTC (f139572)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/202/d5f6386...f139572.html" title="Last updated on Aug 30, 2019, 3:36 AM UTC (f139572)">Diff</a>