### PR TITLE
Note that agent capabilities and other agent-info are public.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1781,11 +1781,14 @@ attacker from changing them or substituting other values during the discovery
 and authentication process.
 
 The following data cannot be reasonably made confidential and should be
-considered public and untrusted data:
+considered public:
 
 1. IP addresses and ports used by the Open Screen Protocol.
 1. Data advertised through mDNS, including the display name prefix, the
     certificate fingerprint, and the metadata version.
+1. Data provided by an agent through [=agent-info=], including its
+    [=display name=], its device model name, its capabilities, and its
+    preferred locales.
 
 ### Cross Origin State Considerations ### {#cross-origin-state}
 

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 220086d88511a9c99d7a1f9b5447db7e7b99e053" name="generator">
   <link href="https://webscreens.github.io/openscreenprotocol/" rel="canonical">
-  <meta content="b222800ecaab84c3d30a47ada2054f99e6473f8f" name="document-revision">
+  <meta content="d5f63863d4ffe819fa73e6e3fdf3cdf4e80d77b6" name="document-revision">
 <style>
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
@@ -1786,8 +1786,8 @@ APIs.</p>
 To do so, agents must use the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6763#section-7" id="ref-for-section-7">Service Name</a> <code>_openscreen._udp.local</code>.</p>
    <p class="issue" id="issue-56c2cd35"><a class="self-link" href="#issue-56c2cd35"></a> Define suspend and resume behavior for discovery protocol. <a href="https://github.com/webscreens/openscreenprotocol/issues/107">&lt;https://github.com/webscreens/openscreenprotocol/issues/107></a></p>
    <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="advertising-agent">advertising agent</dfn> is one that responds to mDNS queries
-for <code>_openscreen._udp.local</code>.  Such an agent should have a <dfn data-dfn-type="dfn" data-lt="display name" data-noexport id="display-name">display
-name<a class="self-link" href="#display-name"></a></dfn> (a non-empty string) that is a human readable description of the
+for <code>_openscreen._udp.local</code>.  Such an agent should have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="display name" data-noexport id="display-name">display
+name</dfn> (a non-empty string) that is a human readable description of the
 presentation display, e.g. "Living Room TV."</p>
    <p>A <dfn data-dfn-type="dfn" data-noexport id="listening-agent">listening agent<a class="self-link" href="#listening-agent"></a></dfn> is one that sends mDNS queries for <code>_openscreen._udp.local</code>.  Listening agents may have a display name.</p>
    <p>Advertising agents must use a DNS-SD <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6763#section-4.1.1" id="ref-for-section-4.1.1">Instance Name</a> that is a prefix of the
@@ -3008,13 +3008,16 @@ considered personally identifiable, are important to protect to prevent an
 attacker from changing them or substituting other values during the discovery
 and authentication process.</p>
    <p>The following data cannot be reasonably made confidential and should be
-considered public and untrusted data:</p>
+considered public:</p>
    <ol>
     <li data-md>
      <p>IP addresses and ports used by the Open Screen Protocol.</p>
     <li data-md>
      <p>Data advertised through mDNS, including the display name prefix, the
 certificate fingerprint, and the metadata version.</p>
+    <li data-md>
+     <p>Data provided by an agent through <a data-link-type="dfn" href="#agent-info" id="ref-for-agent-info⑦">agent-info</a>, including its <a data-link-type="dfn" href="#display-name" id="ref-for-display-name">display name</a>, its device model name, its capabilities, and its
+preferred locales.</p>
    </ol>
    <h4 class="heading settled" data-level="12.2.2" id="cross-origin-state"><span class="secno">12.2.2. </span><span class="content">Cross Origin State Considerations</span><a class="self-link" href="#cross-origin-state"></a></h4>
    <p>Access to origin state across browsing sessions is possible through the
@@ -3132,7 +3135,7 @@ advertised under a given public key fingerprint.</p>
      <p>Untrusted agents that advertise a display name that is similar to that from an
 already-trusted agent.</p>
     <li data-md>
-     <p>Already-trusted agents whose metadata provided through the <a data-link-type="dfn" href="#agent-info" id="ref-for-agent-info⑦">agent-info</a> message has changed.</p>
+     <p>Already-trusted agents whose metadata provided through the <a data-link-type="dfn" href="#agent-info" id="ref-for-agent-info⑧">agent-info</a> message has changed.</p>
    </ul>
    <p>The second is through management of the low-entropy secret during mutual
 authentication:</p>
@@ -4319,6 +4322,12 @@ implementation specific mechanism, quote that here and map it to a message.<a hr
     <li><a href="#ref-for-advertising-agent">6. Authentication</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="display-name">
+   <b><a href="#display-name">#display-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-display-name">12.2.1. Personally Identifiable Information &amp; High-Value Data</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="suspicious-agent">
    <b><a href="#suspicious-agent">#suspicious-agent</a></b><b>Referenced in:</b>
    <ul>
@@ -4357,7 +4366,8 @@ implementation specific mechanism, quote that here and map it to a message.<a hr
     <li><a href="#ref-for-agent-info">4. Transport and metadata discovery with QUIC</a> <a href="#ref-for-agent-info①">(2)</a> <a href="#ref-for-agent-info②">(3)</a> <a href="#ref-for-agent-info③">(4)</a> <a href="#ref-for-agent-info④">(5)</a>
     <li><a href="#ref-for-agent-info⑤">11. Protocol Extensions</a>
     <li><a href="#ref-for-agent-info⑥">11.1. Protocol Extension Fields</a>
-    <li><a href="#ref-for-agent-info⑦">12.5.2. Local active network attackers</a>
+    <li><a href="#ref-for-agent-info⑦">12.2.1. Personally Identifiable Information &amp; High-Value Data</a>
+    <li><a href="#ref-for-agent-info⑧">12.5.2. Local active network attackers</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="agent-status-request">


### PR DESCRIPTION
Follows up on https://github.com/webscreens/openscreenprotocol/issues/123#issuecomment-475760318:

> Should ensure that any capabilities disclosed before authentication are discussed in the Security & Privacy section, and the possible implications thereto.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/pull/203.html" title="Last updated on Aug 30, 2019, 5:22 AM UTC (ccdc0e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/203/d5f6386...ccdc0e7.html" title="Last updated on Aug 30, 2019, 5:22 AM UTC (ccdc0e7)">Diff</a>