### PR TITLE
Make sure deploy script does not delete content

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,9 +35,6 @@ cd out
 git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
 cd ..
 
-# Clean out existing contents
-rm -rf out/**/* || exit 0
-
 echo PWD = $PWD
 # Run our compile script; quit if it fails.
 doCompile || exit 1


### PR DESCRIPTION
The update drops the offending `rm` command that ended up erasing most of the contents of the repository upon deploy.